### PR TITLE
IDVA6-368 remove authorise person success page

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -124,3 +124,4 @@ export const TRUE = "true";
 export const NOT_PROVIDED = "Not provided";
 export const CONFIRMED = "Confirmed";
 export const YES = "yes";
+export const CONFIRM = "confirm";

--- a/src/locales/cy/translation/manage-authorised-people.json
+++ b/src/locales/cy/translation/manage-authorised-people.json
@@ -28,5 +28,10 @@
   "email_resent_success_success_msg1": "[CY] We’ve sent another email to ",
   "email_resent_success_success_msg2": " [CY] They must select the link in the email to be digitally authorised to file online for",
   "cancel_or_remove": "[CY] Cancel or remove",
-  "resend_amail_invitation": "[CY] Resend email invitation"
+  "resend_amail_invitation": "[CY] Resend email invitation",
+  "is_no_longer_digitally_authorised": "[CY] is no longer digitally authorised to file online for ",
+  "you_may_wish_to": "[CY] You may wish to ",
+  "change_the_authentication_code": "[CY] change the authentication code",
+  "for_this_company_if": "[CY] for this company if ",
+  "still_has_access_to_it": "[CY] still has access to it."
 }

--- a/src/locales/cy/translation/manage-authorised-people.json
+++ b/src/locales/cy/translation/manage-authorised-people.json
@@ -1,5 +1,5 @@
 {
-  "back_to_your_companies": "[CY] Back to your companies",
+  "go_back_to_your_companies": "[CY] Go back to ’Your companies’",
   "people_digitally_authorised_to_file_online": "[CY] People digitally authorised to file online for this company",
   "anyone_with_access_to_the_current_authentication": "[CY] Anyone with access to the current authentication code can also file online for this company.",
   "add_new_authorised_person": "[CY] Add new authorised person",
@@ -29,10 +29,9 @@
   "email_resent_success_success_msg2": " [CY] They must select the link in the email to be digitally authorised to file online for",
   "cancel_or_remove": "[CY] Cancel or remove",
   "resend_amail_invitation": "[CY] Resend email invitation",
-  "is_no_longer_digitally_authorised": "[CY] is no longer digitally authorised to file online for ",
+  "is_no_longer_digitally_authorised": " [CY] is no longer digitally authorised to file online for ",
   "you_may_wish_to": "[CY] You may wish to ",
   "change_the_authentication_code": "[CY] change the authentication code",
   "for_this_company_if": "[CY] for this company if ",
-  "still_has_access_to_it": "[CY] still has access to it.",
-  "link_to_company_authentication_codes_for_online_filling": "[CY] Link to Company authentication codes for online filing."
+  "still_has_access_to_it": " [CY] still has access to it."
 }

--- a/src/locales/cy/translation/manage-authorised-people.json
+++ b/src/locales/cy/translation/manage-authorised-people.json
@@ -33,5 +33,6 @@
   "you_may_wish_to": "[CY] You may wish to ",
   "change_the_authentication_code": "[CY] change the authentication code",
   "for_this_company_if": "[CY] for this company if ",
-  "still_has_access_to_it": "[CY] still has access to it."
+  "still_has_access_to_it": "[CY] still has access to it.",
+  "link_to_company_authentication_codes_for_online_filling": "[CY] Link to Company authentication codes for online filing."
 }

--- a/src/locales/en/translation/manage-authorised-people.json
+++ b/src/locales/en/translation/manage-authorised-people.json
@@ -28,5 +28,10 @@
   "email_resent_success_success_msg1": "We’ve sent another email to ",
   "email_resent_success_success_msg2": " They must select the link in the email to be digitally authorised to file online for",
   "cancel_or_remove": "Cancel or remove",
-  "resend_amail_invitation": "Resend email invitation"
+  "resend_amail_invitation": "Resend email invitation",
+  "is_no_longer_digitally_authorised": " is no longer digitally authorised to file online for ",
+  "you_may_wish_to": "You may wish to ",
+  "change_the_authentication_code": "change the authentication code",
+  "for_this_company_if": " for this company if ",
+  "still_has_access_to_it": " still has access to it."
 }

--- a/src/locales/en/translation/manage-authorised-people.json
+++ b/src/locales/en/translation/manage-authorised-people.json
@@ -1,5 +1,5 @@
 {
-  "back_to_your_companies": "Back to your companies",
+  "go_back_to_your_companies": "Go back to ’Your companies’",
   "people_digitally_authorised_to_file_online": "People digitally authorised to file online for this company",
   "anyone_with_access_to_the_current_authentication": "Anyone with access to the current authentication code can also file online for this company.",
   "add_new_authorised_person": "Add new authorised person",
@@ -33,6 +33,5 @@
   "you_may_wish_to": "You may wish to ",
   "change_the_authentication_code": "change the authentication code",
   "for_this_company_if": " for this company if ",
-  "still_has_access_to_it": " still has access to it.",
-  "link_to_company_authentication_codes_for_online_filling": "Link to Company authentication codes for online filing."
+  "still_has_access_to_it": " still has access to it."
 }

--- a/src/locales/en/translation/manage-authorised-people.json
+++ b/src/locales/en/translation/manage-authorised-people.json
@@ -33,5 +33,6 @@
   "you_may_wish_to": "You may wish to ",
   "change_the_authentication_code": "change the authentication code",
   "for_this_company_if": " for this company if ",
-  "still_has_access_to_it": " still has access to it."
+  "still_has_access_to_it": " still has access to it.",
+  "link_to_company_authentication_codes_for_online_filling": "Link to Company authentication codes for online filing."
 }

--- a/src/routers/handlers/yourCompanies/manageAuthorisedPeopleHandler.ts
+++ b/src/routers/handlers/yourCompanies/manageAuthorisedPeopleHandler.ts
@@ -35,6 +35,7 @@ export class ManageAuthorisedPeopleHandler extends GenericHandler {
                 const isUserRemovedFromCompanyAssociations = (await removeUserFromCompanyAssociations(removal.userEmail, removal.companyNumber)) === constants.USER_REMOVED_FROM_COMPANY_ASSOCIATIONS;
                 if (isUserRemovedFromCompanyAssociations) {
                     this.viewData.removedPerson = removal.userName ? removal.userName : removal.userEmail;
+                    this.viewData.changeCompanyAuthCodeUrl = "https://www.gov.uk/guidance/company-authentication-codes-for-online-filing#change-or-cancel-your-code";
                 }
             }
         }

--- a/src/routers/handlers/yourCompanies/manageAuthorisedPeopleHandler.ts
+++ b/src/routers/handlers/yourCompanies/manageAuthorisedPeopleHandler.ts
@@ -24,35 +24,14 @@ export class ManageAuthorisedPeopleHandler extends GenericHandler {
 
         if (cancellation && req.originalUrl.includes(constants.CONFIRMATION_CANCEL_PERSON_URL)) {
             deleteExtraData(req.session, constants.REMOVE_PERSON);
-            if (cancellation.cancelPerson === constants.YES) {
-                const isUserRemovedFromCompanyAssociations = (await removeUserFromCompanyAssociations(cancellation.userEmail, cancellation.companyNumber)) === constants.USER_REMOVED_FROM_COMPANY_ASSOCIATIONS;
-                if (isUserRemovedFromCompanyAssociations) {
-                    this.viewData.cancelledPerson = cancellation.userEmail;
-                }
-            }
+            await this.handleCancellation(cancellation);
         } else if (removal && req.originalUrl.includes(constants.CONFIRMATION_PERSON_REMOVED_URL)) {
             deleteExtraData(req.session, constants.CANCEL_PERSON);
-            if (removal.removePerson === constants.CONFIRM) {
-                const isUserRemovedFromCompanyAssociations = (await removeUserFromCompanyAssociations(removal.userEmail, removal.companyNumber)) === constants.USER_REMOVED_FROM_COMPANY_ASSOCIATIONS;
-                if (isUserRemovedFromCompanyAssociations) {
-                    this.viewData.removedPerson = removal.userName ? removal.userName : removal.userEmail;
-                    this.viewData.changeCompanyAuthCodeUrl = "https://www.gov.uk/guidance/company-authentication-codes-for-online-filing#change-or-cancel-your-code";
-                }
-            }
-        }
-        const authorisedPerson = getExtraData(req.session, constants.AUTHORISED_PERSON);
-
-        if (authorisedPerson && req.originalUrl.includes("/confirmation-person-added")) {
-            this.viewData.authorisedPersonSuccess = true;
-            this.viewData.authorisedPersonEmailAddress = authorisedPerson.authorisedPersonEmailAddress;
-            this.viewData.authorisedPersonCompanyName = authorisedPerson.authorisedPersonCompanyName;
+            await this.handleRemoval(removal);
         }
 
-        const resentSuccessEmail = getExtraData(req.session, constants.RESENT_SUCCESS_EMAIL);
-        if (resentSuccessEmail && req.originalUrl.includes(constants.AUTHORISATION_EMAIL_RESENT_URL)) {
-            this.viewData.showEmailResentSuccess = true;
-            this.viewData.resentSuccessEmail = resentSuccessEmail;
-        }
+        this.handleConfirmationPersonAdded(req);
+        this.handleResentSuccessEmail(req);
 
         const companyAssociations: Associations = await getCompanyAssociations(companyNumber, cancellation || removal);
         this.viewData.companyAssociations = companyAssociations;
@@ -72,5 +51,41 @@ export class ManageAuthorisedPeopleHandler extends GenericHandler {
             resendEmailUrl: constants.YOUR_COMPANIES_MANAGE_AUTHORISED_PEOPLE_EMAIL_RESENT_URL,
             removeUrl: constants.YOUR_COMPANIES_AUTHENTICATION_CODE_REMOVE_URL
         };
+    }
+
+    private async handleCancellation (cancellation: Cancellation) {
+        if (cancellation.cancelPerson === constants.YES) {
+            const isUserRemovedFromCompanyAssociations = (await removeUserFromCompanyAssociations(cancellation.userEmail, cancellation.companyNumber)) === constants.USER_REMOVED_FROM_COMPANY_ASSOCIATIONS;
+            if (isUserRemovedFromCompanyAssociations) {
+                this.viewData.cancelledPerson = cancellation.userEmail;
+            }
+        }
+    }
+
+    private async handleRemoval (removal: Removal) {
+        if (removal.removePerson === constants.CONFIRM) {
+            const isUserRemovedFromCompanyAssociations = (await removeUserFromCompanyAssociations(removal.userEmail, removal.companyNumber)) === constants.USER_REMOVED_FROM_COMPANY_ASSOCIATIONS;
+            if (isUserRemovedFromCompanyAssociations) {
+                this.viewData.removedPerson = removal.userName ? removal.userName : removal.userEmail;
+                this.viewData.changeCompanyAuthCodeUrl = "https://www.gov.uk/guidance/company-authentication-codes-for-online-filing#change-or-cancel-your-code";
+            }
+        }
+    }
+
+    private handleResentSuccessEmail (req: Request) {
+        const resentSuccessEmail = getExtraData(req.session, constants.RESENT_SUCCESS_EMAIL);
+        if (resentSuccessEmail && req.originalUrl.includes(constants.AUTHORISATION_EMAIL_RESENT_URL)) {
+            this.viewData.showEmailResentSuccess = true;
+            this.viewData.resentSuccessEmail = resentSuccessEmail;
+        }
+    }
+
+    private handleConfirmationPersonAdded (req: Request) {
+        const authorisedPerson = getExtraData(req.session, constants.AUTHORISED_PERSON);
+        if (authorisedPerson && req.originalUrl.includes("/confirmation-person-added")) {
+            this.viewData.authorisedPersonSuccess = true;
+            this.viewData.authorisedPersonEmailAddress = authorisedPerson.authorisedPersonEmailAddress;
+            this.viewData.authorisedPersonCompanyName = authorisedPerson.authorisedPersonCompanyName;
+        }
     }
 }

--- a/src/routers/handlers/yourCompanies/manageAuthorisedPeopleHandler.ts
+++ b/src/routers/handlers/yourCompanies/manageAuthorisedPeopleHandler.ts
@@ -34,7 +34,7 @@ export class ManageAuthorisedPeopleHandler extends GenericHandler {
             if (removal.removePerson === constants.YES) {
                 const isUserRemovedFromCompanyAssociations = (await removeUserFromCompanyAssociations(removal.userEmail, removal.companyNumber)) === constants.USER_REMOVED_FROM_COMPANY_ASSOCIATIONS;
                 if (isUserRemovedFromCompanyAssociations) {
-                    this.viewData.removedPerson = removal.userEmail;
+                    this.viewData.removedPerson = removal.userName ? removal.userName : removal.userEmail;
                 }
             }
         }

--- a/src/routers/handlers/yourCompanies/manageAuthorisedPeopleHandler.ts
+++ b/src/routers/handlers/yourCompanies/manageAuthorisedPeopleHandler.ts
@@ -9,6 +9,7 @@ import { getCompanyAssociations, removeUserFromCompanyAssociations } from "../..
 import { getExtraData, setExtraData } from "../../../lib/utils/sessionUtils";
 import { Cancellation } from "../../../types/cancellation";
 import { AnyRecord, ViewData } from "../../../types/util-types";
+import { Removal } from "../../../types/removal";
 
 export class ManageAuthorisedPeopleHandler extends GenericHandler {
 
@@ -20,12 +21,20 @@ export class ManageAuthorisedPeopleHandler extends GenericHandler {
         this.viewData = this.getViewData(companyNumber, lang);
         const cancellation: Cancellation = getExtraData(req.session, constants.CANCEL_PERSON);
         const companyAssociations: Associations = await getCompanyAssociations(companyNumber, cancellation);
+        const removal: Removal = getExtraData(req.session, constants.REMOVE_PERSON);
 
         if (cancellation && req.originalUrl.includes(constants.CONFIRMATION_CANCEL_PERSON_URL)) {
             if (cancellation.cancelPerson === constants.YES) {
                 const isUserRemovedFromCompanyAssociations = (await removeUserFromCompanyAssociations(cancellation.userEmail, cancellation.companyNumber)) === constants.USER_REMOVED_FROM_COMPANY_ASSOCIATIONS;
                 if (isUserRemovedFromCompanyAssociations) {
                     this.viewData.cancelledPerson = cancellation.userEmail;
+                }
+            }
+        } else if (removal && req.originalUrl.includes(constants.CONFIRMATION_PERSON_REMOVED_URL)) {
+            if (removal.removePerson === constants.YES) {
+                const isUserRemovedFromCompanyAssociations = (await removeUserFromCompanyAssociations(removal.userEmail, removal.companyNumber)) === constants.USER_REMOVED_FROM_COMPANY_ASSOCIATIONS;
+                if (isUserRemovedFromCompanyAssociations) {
+                    this.viewData.removedPerson = removal.userEmail;
                 }
             }
         }

--- a/src/routers/router.ts
+++ b/src/routers/router.ts
@@ -22,6 +22,7 @@ router.get(constants.MANAGE_AUTHORISED_PEOPLE_URL, manageAuthorisedPeopleControl
 router.get(constants.MANAGE_AUTHORISED_PEOPLE_CONFIRMATION_CANCEL_PERSON_URL, manageAuthorisedPeopleControllerGet as RequestHandler);
 router.get(constants.MANAGE_AUTHORISED_PEOPLE_CONFIRMATION_EMAIL_RESENT_URL, manageAuthorisedPeopleControllerGet as RequestHandler);
 router.get(constants.AUTHORISED_PERSON_ADDED_URL, manageAuthorisedPeopleControllerGet as RequestHandler);
+router.get(constants.MANAGE_AUTHORISED_PEOPLE_CONFIRMATION_PERSON_REMOVED_URL, manageAuthorisedPeopleControllerGet as RequestHandler);
 
 router.get(constants.ADD_COMPANY_URL, addCompanyControllerGet as RequestHandler);
 router.post(constants.ADD_COMPANY_URL, addCompanyControllerPost as RequestHandler);

--- a/src/views/manage-authorised-people.njk
+++ b/src/views/manage-authorised-people.njk
@@ -21,16 +21,28 @@
 
     {% set company_association = companyAssociations.items | first %}
 
-    {% if cancelledPerson %}
+    {% if cancelledPerson or removedPerson %}
+        {% set heading_text = lang.digital_authorisation_cancelled if cancelledPerson else 
+            removedPerson + lang.is_no_longer_digitally_authorised + company_association.companyName %}
+
         {% set successHtml %}
-        <h3 class="govuk-notification-banner__heading">{{lang.digital_authorisation_cancelled}}</h3>
-        <p class="govuk-body">
-            {{lang.you_have_successfully_cancelled_digital_authorisation_start}}
-            <span class="govuk-body govuk-!-font-weight-bold">{{cancelledPerson}}</span>
-            {{lang.you_have_successfully_cancelled_digital_authorisation_end}}
-            {{company_association.companyName}}
-        </p>
+        <h3 class="govuk-notification-banner__heading">{{heading_text}}</h3>
+        {% if cancelledPerson %}
+            <p class="govuk-body">
+                {{lang.you_have_successfully_cancelled_digital_authorisation_start}}
+                <span class="govuk-body govuk-!-font-weight-bold">{{cancelledPerson}}</span>
+                {{lang.you_have_successfully_cancelled_digital_authorisation_end}}
+                {{company_association.companyName}}
+            </p>
+        {% endif %}
         <p class="govuk-body">{{lang.weve_sent_an_email_to_the_company}}</p>
+        {% if removedPerson %}
+            <p class="govuk-body">
+                {{lang.you_may_wish_to}}
+                <a class="govuk-notification-banner__link">{{lang.change_the_authentication_code}}</a>
+                {{lang.for_this_company_if}}{{removedPerson}}{{lang.still_has_access_to_it}}
+            </p>
+        {% endif %}
         {% endset %}
         <div class="govuk-grid-column-two-thirds">
             {{

--- a/src/views/manage-authorised-people.njk
+++ b/src/views/manage-authorised-people.njk
@@ -39,7 +39,7 @@
         {% if removedPerson %}
             <p class="govuk-body">
                 {{lang.you_may_wish_to}}
-                <a class="govuk-notification-banner__link">{{lang.change_the_authentication_code}}</a>
+                <a class="govuk-notification-banner__link" href="{{changeCompanyAuthCodeUrl}}" target="_blank" rel="noopener noreferrer" aria-label="{{lang.link_to_company_authentication_codes_for_online_filling}}">{{lang.change_the_authentication_code}}</a>
                 {{lang.for_this_company_if}}{{removedPerson}}{{lang.still_has_access_to_it}}
             </p>
         {% endif %}

--- a/src/views/manage-authorised-people.njk
+++ b/src/views/manage-authorised-people.njk
@@ -12,7 +12,7 @@
 {% block back_link %}
 
     <div role="navigation" aria-label="{{lang.link_back_to_previous_page}}">
-        {{ govukBackLink({text: lang.back_to_your_companies, href: backLinkHref }) }}
+        {{ govukBackLink({text: lang.go_back_to_your_companies, href: backLinkHref }) }}
     </div>
 
 {% endblock %}
@@ -23,7 +23,7 @@
 
     {% if cancelledPerson or removedPerson %}
         {% set heading_text = lang.digital_authorisation_cancelled if cancelledPerson else 
-            removedPerson + lang.is_no_longer_digitally_authorised + company_association.companyName %}
+            removedPerson + lang.is_no_longer_digitally_authorised + company_association.companyName + "." %}
 
         {% set successHtml %}
         <h3 class="govuk-notification-banner__heading">{{heading_text}}</h3>
@@ -39,7 +39,7 @@
         {% if removedPerson %}
             <p class="govuk-body">
                 {{lang.you_may_wish_to}}
-                <a class="govuk-notification-banner__link" href="{{changeCompanyAuthCodeUrl}}" target="_blank" rel="noopener noreferrer" aria-label="{{lang.link_to_company_authentication_codes_for_online_filling}}">{{lang.change_the_authentication_code}}</a>
+                <a class="govuk-notification-banner__link" href="{{changeCompanyAuthCodeUrl}}" target="_blank" rel="noopener noreferrer">{{lang.change_the_authentication_code}}</a>
                 {{lang.for_this_company_if}}{{removedPerson}}{{lang.still_has_access_to_it}}
             </p>
         {% endif %}
@@ -123,7 +123,11 @@
             {% set tag = govukTag({text: lang.confirmed.toUpperCase(), classes: "govuk-tag--green"}) %}
             {% set row = (row.push({html: tag}), row) %}
             {% set removeLinkAriaLabelText = lang.link_to_remove_user_from_digitaly_authorised_start + association.userEmail + lang.link_to_remove_user_from_digitaly_authorised_end + association.companyName %}
-            {% set query_params = {userName: association.displayName} if association.displayName and association.displayName !== "Not provided" else undefined %}
+            {% set query_params = {
+                userName: association.displayName
+            }
+            if association.displayName and association.displayName !== "Not provided" else 
+                undefined %}
             {% set removeLink = link(lang.remove, removeLinkAriaLabelText, removeUrl, {
                 userEmail: association.userEmail,
                 companyNumber: association.companyNumber

--- a/src/views/remove-authorised-person.njk
+++ b/src/views/remove-authorised-person.njk
@@ -5,7 +5,8 @@
 
 {% extends "layouts/default.njk" %}
 
-{% set user_details = userName if userName else userEmail %}
+{% set user_details = userName if userName else 
+    userEmail %}
 {% set title = lang.remove + user_details + lang.authorisation_to_file_online + lang.title_end %}
 
 {% block back_link %}
@@ -26,21 +27,21 @@
     {% endfor %}
 
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-grid-column-two-thirds">
             <span class="govuk-caption-xl">{{ companyName }}</span>
             <h1 class = "govuk-heading-xl">
                 {{ lang.remove + user_details + lang.authorisation_to_file_online }}
             </h1>
 
             <p>{{ lang.if_you_remove + user_details + lang.digital_authorisation_this_means_they + companyName + lang.without_a_current_auth_code + user_details + lang.to_let_them_know_you_have_removed }}</p>
-        
+
             {% set warning_text_html %}
-                <span class="govuk-!-display-block govuk-!-margin-bottom-5">
-                    {{ user_details + lang.will_still_be_able_to_file }}
-                </span>
-                <span class="govuk-!-display-block">
-                    {{ lang.you_may_wish_to_change_the_auth_code + user_details + lang.digital_authorisation }}
-                </span>
+            <span class="govuk-!-display-block govuk-!-margin-bottom-5">
+                {{ user_details + lang.will_still_be_able_to_file }}
+            </span>
+            <span class="govuk-!-display-block">
+                {{ lang.you_may_wish_to_change_the_auth_code + user_details + lang.digital_authorisation }}
+            </span>
             {% endset %}
 
             {{
@@ -54,7 +55,7 @@
             <p>{{ lang.if + user_details + lang.is_appointed_as_an_officer }}</p>
 
             <form method = "post">
-              {{ govukCheckboxes({
+                {{ govukCheckboxes({
                         name: "confirmRemoval",
 
                         items: [{
@@ -64,7 +65,7 @@
                         errorMessage: message
                     }) 
                 }}
-                
+
                 <div class="govuk-button-group">
 
                     {{ govukButton({
@@ -75,12 +76,9 @@
                     <a class="govuk-link" href="{{ cancelLinkHref }}">{{ lang.cancel }}</a>
 
                 </div>
-            
-            </form> 
-      
-      </div>
+
+            </form>
+
+        </div>
     </div>
 {% endblock %}
-
-
-

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.authorisationEmailResent.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.authorisationEmailResent.test.ts
@@ -1,0 +1,75 @@
+import mocks from "../../../mocks/all.middleware.mock";
+import { companyAssociations } from "../../../mocks/associations.mock";
+import app from "../../../../src/app";
+import * as userCompanyAssociationService from "../../../../src/services/userCompanyAssociationService";
+import supertest from "supertest";
+import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
+
+const router = supertest(app);
+
+jest.mock("../../../../src/lib/Logger");
+jest.mock("../../../../src/lib/utils/sessionUtils", () => {
+    const originalModule = jest.requireActual("../../../../src/lib/utils/sessionUtils");
+
+    return {
+        __esModule: true,
+        ...originalModule,
+        getLoggedInUserEmail: jest.fn(() => "test@test.com"),
+        setExtraData: jest.fn(),
+        deleteExtraData: jest.fn()
+    };
+});
+
+describe("GET /your-companies/manage-authorised-people/:companyNumber/authorisation-email-resent", () => {
+    const companyNumber = "NI038379";
+    const url = `/your-companies/manage-authorised-people/${companyNumber}/authorisation-email-resent`;
+    const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
+    const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
+    const en = require("../../../../src/locales/en/translation/manage-authorised-people.json");
+    const cy = require("../../../../src/locales/cy/translation/manage-authorised-people.json");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const resentSuccessEmail = "bob@bob.com";
+    getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+
+    it("should check session and auth before returning the /your-companies/manage-authorised-people/NI038379/authorisation-email-resent page", async () => {
+        getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+        await router.get(url);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+    });
+
+    it("should return status 200", async () => {
+        getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+        const response = await router.get(url);
+        expect(response.status).toEqual(200);
+    });
+
+    it("should return expected English content if language version set to English", async () => {
+        sessionUtilsSpy.mockReturnValue(resentSuccessEmail);
+
+        const response = await router.get(`${url}?lang=en`);
+        expect(response.text).toContain(en.authorised_person_success_heading);
+        expect(response.text).toContain(en.email_resent_success_success_msg1);
+        expect(response.text).toContain(en.email_resent_success_success_msg1);
+        expect(response.text).toContain("bob@bob.com");
+    });
+
+    it("should return expected Welsh content if language version set to Welsh", async () => {
+        sessionUtilsSpy.mockReturnValue(resentSuccessEmail);
+        const response = await router.get(`${url}?lang=cy`);
+        expect(response.text).toContain(cy.authorised_person_success_heading);
+        expect(response.text).toContain(cy.email_resent_success_success_msg1);
+        expect(response.text).toContain(cy.email_resent_success_success_msg1);
+        expect(response.text).toContain("bob@bob.com");
+    });
+    it("should not display banner if no authorised person details saved in session", async () => {
+        sessionUtilsSpy.mockReturnValue(undefined);
+        const response = await router.get(`${url}?lang=en`);
+        expect(response.text.includes(en.email_resent_success_success_msg1)).toBe(false);
+        expect(response.text.includes("bob@bob.com")).toBe(false);
+    });
+});

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.authorisationEmailResent.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.authorisationEmailResent.test.ts
@@ -4,6 +4,8 @@ import app from "../../../../src/app";
 import * as userCompanyAssociationService from "../../../../src/services/userCompanyAssociationService";
 import supertest from "supertest";
 import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
+import * as en from "../../../../src/locales/en/translation/manage-authorised-people.json";
+import * as cy from "../../../../src/locales/cy/translation/manage-authorised-people.json";
 
 const router = supertest(app);
 
@@ -25,8 +27,6 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/authorisat
     const url = `/your-companies/manage-authorised-people/${companyNumber}/authorisation-email-resent`;
     const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
     const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
-    const en = require("../../../../src/locales/en/translation/manage-authorised-people.json");
-    const cy = require("../../../../src/locales/cy/translation/manage-authorised-people.json");
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationCancelPerson.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationCancelPerson.test.ts
@@ -1,0 +1,119 @@
+import mocks from "../../../mocks/all.middleware.mock";
+import { companyAssociations } from "../../../mocks/associations.mock";
+import app from "../../../../src/app";
+import * as userCompanyAssociationService from "../../../../src/services/userCompanyAssociationService";
+import supertest from "supertest";
+import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
+import { Cancellation } from "../../../../src/types/cancellation";
+import { USER_REMOVED_FROM_COMPANY_ASSOCIATIONS, YES } from "../../../../src/constants";
+
+const router = supertest(app);
+
+jest.mock("../../../../src/lib/Logger");
+jest.mock("../../../../src/lib/utils/sessionUtils", () => {
+    const originalModule = jest.requireActual("../../../../src/lib/utils/sessionUtils");
+
+    return {
+        __esModule: true,
+        ...originalModule,
+        getLoggedInUserEmail: jest.fn(() => "test@test.com"),
+        setExtraData: jest.fn(),
+        deleteExtraData: jest.fn()
+    };
+});
+
+const en = require("../../../../src/locales/en/translation/manage-authorised-people.json");
+const cy = require("../../../../src/locales/cy/translation/manage-authorised-people.json");
+const enCommon = require("../../../../src/locales/en/translation/common.json");
+const cyCommon = require("../../../../src/locales/cy/translation/common.json");
+const companyNumber = "NI038379";
+
+describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-cancel-person", () => {
+    const url = `/your-companies/manage-authorised-people/${companyNumber}/confirmation-cancel-person`;
+    const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
+    const removeUserFromCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "removeUserFromCompanyAssociations");
+    const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should check session and auth before returning the /your-companies/manage-authorised-people/NI038379 page", async () => {
+        getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+        await router.get(url);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+    });
+
+    it("should return expected English content if person cancelled and language version set to English", async () => {
+    // Given
+        const cancellation: Cancellation = {
+            cancelPerson: YES,
+            userEmail: companyAssociations.items[0].userEmail,
+            companyNumber: companyAssociations.items[0].companyNumber
+        };
+        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== cancellation.userEmail);
+        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+        sessionUtilsSpy.mockReturnValue(cancellation);
+        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
+        // When
+        const response = await router.get(`${url}?lang=en`);
+        // Then
+        expect(response.text).toContain(enCommon.success);
+        expect(response.text).toContain(en.digital_authorisation_cancelled);
+        expect(response.text).toContain(en.you_have_successfully_cancelled_digital_authorisation_start);
+        expect(response.text).toContain(en.you_have_successfully_cancelled_digital_authorisation_end);
+        expect(response.text).toContain(en.weve_sent_an_email_to_the_company);
+        expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
+        expect(response.text).toContain(en.people_digitally_authorised_to_file_online);
+        expect(response.text).toContain(en.anyone_with_access_to_the_current_authentication);
+        expect(response.text).toContain(en.add_new_authorised_person);
+        expect(response.text).toContain(en.details_of_authorised_people);
+        expect(response.text).toContain(en.email_address);
+        expect(response.text).toContain(en.name);
+        expect(response.text).toContain(en.status);
+        expect(response.text).toContain(en.remove);
+        expect(response.text).toContain(en.back_to_your_companies);
+        expect(response.text).not.toContain(companyAssociations.items[0].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
+    });
+
+    it("should return expected Welsh content if person cancelled and language version set to Welsh", async () => {
+    // Given
+        const cancellation: Cancellation = {
+            cancelPerson: YES,
+            userEmail: companyAssociations.items[0].userEmail,
+            companyNumber: companyAssociations.items[0].companyNumber
+        };
+        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== cancellation.userEmail);
+        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+        sessionUtilsSpy.mockReturnValue(cancellation);
+        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
+        // When
+        const response = await router.get(`${url}?lang=cy`);
+        // Then
+        expect(response.text).toContain(cyCommon.success);
+        expect(response.text).toContain(cy.digital_authorisation_cancelled);
+        expect(response.text).toContain(cy.you_have_successfully_cancelled_digital_authorisation_start);
+        expect(response.text).toContain(cy.you_have_successfully_cancelled_digital_authorisation_end);
+        expect(response.text).toContain(cy.weve_sent_an_email_to_the_company);
+        expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
+        expect(response.text).toContain(cy.people_digitally_authorised_to_file_online);
+        expect(response.text).toContain(cy.anyone_with_access_to_the_current_authentication);
+        expect(response.text).toContain(cy.add_new_authorised_person);
+        expect(response.text).toContain(cy.details_of_authorised_people);
+        expect(response.text).toContain(cy.email_address);
+        expect(response.text).toContain(cy.name);
+        expect(response.text).toContain(cy.status);
+        expect(response.text).toContain(cy.remove);
+        expect(response.text).toContain(cy.back_to_your_companies);
+        expect(response.text).not.toContain(companyAssociations.items[0].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
+    });
+});

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationCancelPerson.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationCancelPerson.test.ts
@@ -6,6 +6,10 @@ import supertest from "supertest";
 import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
 import { Cancellation } from "../../../../src/types/cancellation";
 import { USER_REMOVED_FROM_COMPANY_ASSOCIATIONS, YES } from "../../../../src/constants";
+import * as en from "../../../../src/locales/en/translation/manage-authorised-people.json";
+import * as cy from "../../../../src/locales/cy/translation/manage-authorised-people.json";
+import * as enCommon from "../../../../src/locales/en/translation/common.json";
+import * as cyCommon from "../../../../src/locales/cy/translation/common.json";
 
 const router = supertest(app);
 
@@ -22,10 +26,6 @@ jest.mock("../../../../src/lib/utils/sessionUtils", () => {
     };
 });
 
-const en = require("../../../../src/locales/en/translation/manage-authorised-people.json");
-const cy = require("../../../../src/locales/cy/translation/manage-authorised-people.json");
-const enCommon = require("../../../../src/locales/en/translation/common.json");
-const cyCommon = require("../../../../src/locales/cy/translation/common.json");
 const companyNumber = "NI038379";
 
 describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-cancel-person", () => {
@@ -46,7 +46,7 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
     });
 
     it("should return expected English content if person cancelled and language version set to English", async () => {
-    // Given
+        // Given
         const cancellation: Cancellation = {
             cancelPerson: YES,
             userEmail: companyAssociations.items[0].userEmail,
@@ -82,7 +82,7 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
     });
 
     it("should return expected Welsh content if person cancelled and language version set to Welsh", async () => {
-    // Given
+        // Given
         const cancellation: Cancellation = {
             cancelPerson: YES,
             userEmail: companyAssociations.items[0].userEmail,

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationCancelPerson.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationCancelPerson.test.ts
@@ -74,7 +74,7 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
         expect(response.text).toContain(en.name);
         expect(response.text).toContain(en.status);
         expect(response.text).toContain(en.remove);
-        expect(response.text).toContain(en.back_to_your_companies);
+        expect(response.text).toContain(en.go_back_to_your_companies);
         expect(response.text).not.toContain(companyAssociations.items[0].userEmail + "</th>");
         expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
         expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
@@ -110,7 +110,7 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
         expect(response.text).toContain(cy.name);
         expect(response.text).toContain(cy.status);
         expect(response.text).toContain(cy.remove);
-        expect(response.text).toContain(cy.back_to_your_companies);
+        expect(response.text).toContain(cy.go_back_to_your_companies);
         expect(response.text).not.toContain(companyAssociations.items[0].userEmail + "</th>");
         expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
         expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationPersonAdded.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationPersonAdded.test.ts
@@ -1,0 +1,83 @@
+import mocks from "../../../mocks/all.middleware.mock";
+import { companyAssociations } from "../../../mocks/associations.mock";
+import app from "../../../../src/app";
+import * as userCompanyAssociationService from "../../../../src/services/userCompanyAssociationService";
+import supertest from "supertest";
+import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
+import { AuthorisedPerson } from "../../../../src/types/associations";
+
+const router = supertest(app);
+
+jest.mock("../../../../src/lib/Logger");
+jest.mock("../../../../src/lib/utils/sessionUtils", () => {
+    const originalModule = jest.requireActual("../../../../src/lib/utils/sessionUtils");
+
+    return {
+        __esModule: true,
+        ...originalModule,
+        getLoggedInUserEmail: jest.fn(() => "test@test.com"),
+        setExtraData: jest.fn(),
+        deleteExtraData: jest.fn()
+    };
+});
+
+describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-person-added", () => {
+    const companyNumber = "NI038379";
+    const url = `/your-companies/manage-authorised-people/${companyNumber}/confirmation-person-added`;
+    const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
+    const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
+    const en = require("../../../../src/locales/en/translation/manage-authorised-people.json");
+    const cy = require("../../../../src/locales/cy/translation/manage-authorised-people.json");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const authorisedPerson:AuthorisedPerson = {
+        authorisedPersonEmailAddress: "bob@bob.com",
+        authorisedPersonCompanyName: "Acme Ltd"
+    };
+    // sessionUtilsSpy.mockReturnValue(authorisedPerson);
+    getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+
+    it("should check session and auth before returning the /your-companies/manage-authorised-people/NI038379/confirmation-person-added page", async () => {
+        getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+        await router.get(url);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+    });
+
+    it("should return status 200", async () => {
+        getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+        const response = await router.get(url);
+        expect(response.status).toEqual(200);
+    });
+
+    it("should return expected English content if language version set to English", async () => {
+        sessionUtilsSpy.mockReturnValue(authorisedPerson);
+
+        const response = await router.get(`${url}?lang=en`);
+        expect(response.text).toContain(en.authorised_person_success_heading);
+        expect(response.text).toContain(en.authorised_person_success_msg1);
+        expect(response.text).toContain(en.authorised_person_success_msg2);
+        expect(response.text).toContain("Acme Ltd");
+        expect(response.text).toContain("bob@bob.com");
+    });
+
+    it("should return expected Welsh content if language version set to Welsh", async () => {
+        sessionUtilsSpy.mockReturnValue(authorisedPerson);
+        const response = await router.get(`${url}?lang=cy`);
+        expect(response.text).toContain(cy.authorised_person_success_heading);
+        expect(response.text).toContain(cy.authorised_person_success_msg1);
+        expect(response.text).toContain(cy.authorised_person_success_msg2);
+        expect(response.text).toContain("Acme Ltd");
+        expect(response.text).toContain("bob@bob.com");
+    });
+    it("should not display banner if no authorised person details saved in session", async () => {
+        sessionUtilsSpy.mockReturnValue(undefined);
+        const response = await router.get(`${url}?lang=en`);
+        expect(response.text.includes(en.authorised_person_success_heading)).toBe(false);
+        expect(response.text.includes("Acme Ltd")).toBe(false);
+        expect(response.text.includes("bob@bob.com")).toBe(false);
+    });
+});

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationPersonAdded.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationPersonAdded.test.ts
@@ -5,6 +5,8 @@ import * as userCompanyAssociationService from "../../../../src/services/userCom
 import supertest from "supertest";
 import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
 import { AuthorisedPerson } from "../../../../src/types/associations";
+import * as en from "../../../../src/locales/en/translation/manage-authorised-people.json";
+import * as cy from "../../../../src/locales/cy/translation/manage-authorised-people.json";
 
 const router = supertest(app);
 
@@ -26,14 +28,12 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
     const url = `/your-companies/manage-authorised-people/${companyNumber}/confirmation-person-added`;
     const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
     const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
-    const en = require("../../../../src/locales/en/translation/manage-authorised-people.json");
-    const cy = require("../../../../src/locales/cy/translation/manage-authorised-people.json");
 
     beforeEach(() => {
         jest.clearAllMocks();
     });
 
-    const authorisedPerson:AuthorisedPerson = {
+    const authorisedPerson: AuthorisedPerson = {
         authorisedPersonEmailAddress: "bob@bob.com",
         authorisedPersonCompanyName: "Acme Ltd"
     };

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationPersonRemoved.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationPersonRemoved.test.ts
@@ -6,6 +6,10 @@ import supertest from "supertest";
 import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
 import { CONFIRM, USER_REMOVED_FROM_COMPANY_ASSOCIATIONS, YES } from "../../../../src/constants";
 import { Removal } from "../../../../src/types/removal";
+import * as en from "../../../../src/locales/en/translation/manage-authorised-people.json";
+import * as cy from "../../../../src/locales/cy/translation/manage-authorised-people.json";
+import * as enCommon from "../../../../src/locales/en/translation/common.json";
+import * as cyCommon from "../../../../src/locales/cy/translation/common.json";
 
 const router = supertest(app);
 
@@ -22,10 +26,6 @@ jest.mock("../../../../src/lib/utils/sessionUtils", () => {
     };
 });
 
-const en = require("../../../../src/locales/en/translation/manage-authorised-people.json");
-const cy = require("../../../../src/locales/cy/translation/manage-authorised-people.json");
-const enCommon = require("../../../../src/locales/en/translation/common.json");
-const cyCommon = require("../../../../src/locales/cy/translation/common.json");
 const companyNumber = "NI038379";
 
 describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-person-removed", () => {
@@ -46,7 +46,7 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
     });
 
     it("should return expected English content if person removed, their name not provided and language version set to English", async () => {
-    // Given
+        // Given
         const removal: Removal = {
             removePerson: CONFIRM,
             userEmail: companyAssociations.items[1].userEmail,
@@ -74,7 +74,7 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
     });
 
     it("should return expected Welsh content if person removed, their name not provided and language version set to Welsh", async () => {
-    // Given
+        // Given
         const removal: Removal = {
             removePerson: CONFIRM,
             userEmail: companyAssociations.items[1].userEmail,
@@ -102,7 +102,7 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
     });
 
     it("should return expected English content if person removed, their name provided and language version set to English", async () => {
-    // Given
+        // Given
         const removal: Removal = {
             removePerson: CONFIRM,
             userEmail: companyAssociations.items[3].userEmail,
@@ -131,7 +131,7 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
     });
 
     it("should return expected Welsh content if person removed, their name provided and language version set to Welsh", async () => {
-    // Given
+        // Given
         const removal: Removal = {
             removePerson: CONFIRM,
             userEmail: companyAssociations.items[3].userEmail,

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationPersonRemoved.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationPersonRemoved.test.ts
@@ -1,0 +1,161 @@
+import mocks from "../../../mocks/all.middleware.mock";
+import { companyAssociations } from "../../../mocks/associations.mock";
+import app from "../../../../src/app";
+import * as userCompanyAssociationService from "../../../../src/services/userCompanyAssociationService";
+import supertest from "supertest";
+import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
+import { CONFIRM, USER_REMOVED_FROM_COMPANY_ASSOCIATIONS, YES } from "../../../../src/constants";
+import { Removal } from "../../../../src/types/removal";
+
+const router = supertest(app);
+
+jest.mock("../../../../src/lib/Logger");
+jest.mock("../../../../src/lib/utils/sessionUtils", () => {
+    const originalModule = jest.requireActual("../../../../src/lib/utils/sessionUtils");
+
+    return {
+        __esModule: true,
+        ...originalModule,
+        getLoggedInUserEmail: jest.fn(() => "test@test.com"),
+        setExtraData: jest.fn(),
+        deleteExtraData: jest.fn()
+    };
+});
+
+const en = require("../../../../src/locales/en/translation/manage-authorised-people.json");
+const cy = require("../../../../src/locales/cy/translation/manage-authorised-people.json");
+const enCommon = require("../../../../src/locales/en/translation/common.json");
+const cyCommon = require("../../../../src/locales/cy/translation/common.json");
+const companyNumber = "NI038379";
+
+describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-person-removed", () => {
+    const url = `/your-companies/manage-authorised-people/${companyNumber}/confirmation-person-removed`;
+    const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
+    const removeUserFromCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "removeUserFromCompanyAssociations");
+    const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should check session and auth before returning the /your-companies/manage-authorised-people/NI038379 page", async () => {
+        getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+        await router.get(url);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+    });
+
+    it("should return expected English content if person removed, their name not provided and language version set to English", async () => {
+    // Given
+        const removal: Removal = {
+            removePerson: CONFIRM,
+            userEmail: companyAssociations.items[1].userEmail,
+            companyNumber: companyAssociations.items[1].companyNumber
+        };
+        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
+        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+        const expectedBannerHeaderText = companyAssociations.items[1].userEmail + en.is_no_longer_digitally_authorised + companyAssociations.items[1].companyName;
+        sessionUtilsSpy.mockReturnValue(removal);
+        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
+        // When
+        const response = await router.get(`${url}?lang=en`);
+        // Then
+        expect(response.text).toContain(enCommon.success);
+        expect(response.text).toContain(expectedBannerHeaderText);
+        expect(response.text).toContain(en.weve_sent_an_email_to_the_company);
+        expect(response.text).toContain(en.you_may_wish_to);
+        expect(response.text).toContain(en.change_the_authentication_code);
+        expect(response.text).toContain(en.for_this_company_if + companyAssociations.items[1].userEmail + en.still_has_access_to_it);
+        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+        expect(response.text).not.toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
+    });
+
+    it("should return expected Welsh content if person removed, their name not provided and language version set to Welsh", async () => {
+    // Given
+        const removal: Removal = {
+            removePerson: CONFIRM,
+            userEmail: companyAssociations.items[1].userEmail,
+            companyNumber: companyAssociations.items[1].companyNumber
+        };
+        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
+        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+        const expectedBannerHeaderText = companyAssociations.items[1].userEmail + cy.is_no_longer_digitally_authorised + companyAssociations.items[1].companyName;
+        sessionUtilsSpy.mockReturnValue(removal);
+        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
+        // When
+        const response = await router.get(`${url}?lang=cy`);
+        // Then
+        expect(response.text).toContain(cyCommon.success);
+        expect(response.text).toContain(expectedBannerHeaderText);
+        expect(response.text).toContain(cy.weve_sent_an_email_to_the_company);
+        expect(response.text).toContain(cy.you_may_wish_to);
+        expect(response.text).toContain(cy.change_the_authentication_code);
+        expect(response.text).toContain(cy.for_this_company_if + companyAssociations.items[1].userEmail + cy.still_has_access_to_it);
+        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+        expect(response.text).not.toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
+    });
+
+    it("should return expected English content if person removed, their name provided and language version set to English", async () => {
+    // Given
+        const removal: Removal = {
+            removePerson: CONFIRM,
+            userEmail: companyAssociations.items[3].userEmail,
+            userName: companyAssociations.items[3].displayName,
+            companyNumber: companyAssociations.items[3].companyNumber
+        };
+        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
+        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+        const expectedBannerHeaderText = companyAssociations.items[3].displayName + en.is_no_longer_digitally_authorised + companyAssociations.items[3].companyName;
+        sessionUtilsSpy.mockReturnValue(removal);
+        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
+        // When
+        const response = await router.get(`${url}?lang=en`);
+        // Then
+        expect(response.text).toContain(enCommon.success);
+        expect(response.text).toContain(expectedBannerHeaderText);
+        expect(response.text).toContain(en.weve_sent_an_email_to_the_company);
+        expect(response.text).toContain(en.you_may_wish_to);
+        expect(response.text).toContain(en.change_the_authentication_code);
+        expect(response.text).toContain(en.for_this_company_if + companyAssociations.items[3].displayName + en.still_has_access_to_it);
+        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+        expect(response.text).not.toContain(companyAssociations.items[3].userEmail + "</th>");
+    });
+
+    it("should return expected Welsh content if person removed, their name provided and language version set to Welsh", async () => {
+    // Given
+        const removal: Removal = {
+            removePerson: CONFIRM,
+            userEmail: companyAssociations.items[3].userEmail,
+            userName: companyAssociations.items[3].displayName,
+            companyNumber: companyAssociations.items[3].companyNumber
+        };
+        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
+        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+        const expectedBannerHeaderText = companyAssociations.items[3].displayName + cy.is_no_longer_digitally_authorised + companyAssociations.items[3].companyName;
+        sessionUtilsSpy.mockReturnValue(removal);
+        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
+        // When
+        const response = await router.get(`${url}?lang=cy`);
+        // Then
+        expect(response.text).toContain(cyCommon.success);
+        expect(response.text).toContain(expectedBannerHeaderText);
+        expect(response.text).toContain(cy.weve_sent_an_email_to_the_company);
+        expect(response.text).toContain(cy.you_may_wish_to);
+        expect(response.text).toContain(cy.change_the_authentication_code);
+        expect(response.text).toContain(cy.for_this_company_if + companyAssociations.items[3].displayName + cy.still_has_access_to_it);
+        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+        expect(response.text).not.toContain(companyAssociations.items[3].userEmail + "</th>");
+    });
+});

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationPersonRemoved.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.confirmationPersonRemoved.test.ts
@@ -4,7 +4,7 @@ import app from "../../../../src/app";
 import * as userCompanyAssociationService from "../../../../src/services/userCompanyAssociationService";
 import supertest from "supertest";
 import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
-import { CONFIRM, USER_REMOVED_FROM_COMPANY_ASSOCIATIONS, YES } from "../../../../src/constants";
+import { CONFIRM, USER_REMOVED_FROM_COMPANY_ASSOCIATIONS } from "../../../../src/constants";
 import { Removal } from "../../../../src/types/removal";
 import * as en from "../../../../src/locales/en/translation/manage-authorised-people.json";
 import * as cy from "../../../../src/locales/cy/translation/manage-authorised-people.json";

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
@@ -5,7 +5,7 @@ import * as userCompanyAssociationService from "../../../../src/services/userCom
 import supertest from "supertest";
 import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
 import { Cancellation } from "../../../../src/types/cancellation";
-import { USER_REMOVED_FROM_COMPANY_ASSOCIATIONS, YES } from "../../../../src/constants";
+import { CONFIRM, USER_REMOVED_FROM_COMPANY_ASSOCIATIONS, YES } from "../../../../src/constants";
 import { AuthorisedPerson } from "../../../../src/types/associations";
 import * as en from "../../../../src/locales/en/translation/manage-authorised-people.json";
 import * as cy from "../../../../src/locales/cy/translation/manage-authorised-people.json";
@@ -30,219 +30,220 @@ jest.mock("../../../../src/lib/utils/sessionUtils", () => {
 
 const companyNumber = "NI038379";
 
-describe("GET /your-companies/manage-authorised-people/:companyNumber", () => {
-    const url = `/your-companies/manage-authorised-people/${companyNumber}`;
-    const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
-    const removeUserFromCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "removeUserFromCompanyAssociations");
-    const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
+describe("Manage Authorised People Controller", () => {
+    describe("GET /your-companies/manage-authorised-people/:companyNumber", () => {
+        const url = `/your-companies/manage-authorised-people/${companyNumber}`;
+        const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
 
-    beforeEach(() => {
-        jest.clearAllMocks();
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it("should check session and auth before returning the /your-companies/manage-authorised-people/NI038379 page", async () => {
+            getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+            await router.get(url);
+            expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+            expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+        });
+
+        it("should return status 200", async () => {
+            // Given
+            getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+            // When
+            const response = await router.get(url);
+            // Then
+            expect(response.status).toEqual(200);
+        });
+
+        it("should return expected English content if language version set to English", async () => {
+            // Given
+            getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+            // When
+            const response = await router.get(`${url}?lang=en`);
+            // Then
+            expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
+            expect(response.text).toContain(en.people_digitally_authorised_to_file_online);
+            expect(response.text).toContain(en.anyone_with_access_to_the_current_authentication);
+            expect(response.text).toContain(en.add_new_authorised_person);
+            expect(response.text).toContain(en.details_of_authorised_people);
+            expect(response.text).toContain(en.email_address);
+            expect(response.text).toContain(en.name);
+            expect(response.text).toContain(en.status);
+            expect(response.text).toContain(en.remove);
+            expect(response.text).toContain(en.back_to_your_companies);
+            expect(response.text).not.toContain(enCommon.success);
+            expect(response.text).not.toContain(en.digital_authorisation_cancelled);
+            expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
+        });
+
+        it("should return expected Welsh content if language version set to Welsh", async () => {
+            // Given
+            getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+            // When
+            const response = await router.get(`${url}?lang=cy`);
+            // Then
+            expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
+            expect(response.text).toContain(cy.people_digitally_authorised_to_file_online);
+            expect(response.text).toContain(cy.anyone_with_access_to_the_current_authentication);
+            expect(response.text).toContain(cy.add_new_authorised_person);
+            expect(response.text).toContain(cy.details_of_authorised_people);
+            expect(response.text).toContain(cy.email_address);
+            expect(response.text).toContain(cy.name);
+            expect(response.text).toContain(cy.status);
+            expect(response.text).toContain(cy.remove);
+            expect(response.text).toContain(cy.back_to_your_companies);
+            expect(response.text).not.toContain(cyCommon.success);
+            expect(response.text).not.toContain(cy.digital_authorisation_cancelled);
+            expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
+        });
     });
 
-    it("should check session and auth before returning the /your-companies/manage-authorised-people/NI038379 page", async () => {
-        getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-        await router.get(url);
-        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
-        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+    describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-cancel-person", () => {
+        const url = `/your-companies/manage-authorised-people/${companyNumber}/confirmation-cancel-person`;
+        const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
+        const removeUserFromCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "removeUserFromCompanyAssociations");
+        const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        it("should return expected English content if person cancelled and language version set to English", async () => {
+            // Given
+            const cancellation: Cancellation = {
+                cancelPerson: YES,
+                userEmail: companyAssociations.items[0].userEmail,
+                companyNumber: companyAssociations.items[0].companyNumber
+            };
+            const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+            expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== cancellation.userEmail);
+            getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+            sessionUtilsSpy.mockReturnValue(cancellation);
+            removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
+            // When
+            const response = await router.get(`${url}?lang=en`);
+            // Then
+            expect(response.text).toContain(enCommon.success);
+            expect(response.text).toContain(en.digital_authorisation_cancelled);
+            expect(response.text).toContain(en.you_have_successfully_cancelled_digital_authorisation_start);
+            expect(response.text).toContain(en.you_have_successfully_cancelled_digital_authorisation_end);
+            expect(response.text).toContain(en.weve_sent_an_email_to_the_company);
+            expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
+            expect(response.text).toContain(en.people_digitally_authorised_to_file_online);
+            expect(response.text).toContain(en.anyone_with_access_to_the_current_authentication);
+            expect(response.text).toContain(en.add_new_authorised_person);
+            expect(response.text).toContain(en.details_of_authorised_people);
+            expect(response.text).toContain(en.email_address);
+            expect(response.text).toContain(en.name);
+            expect(response.text).toContain(en.status);
+            expect(response.text).toContain(en.remove);
+            expect(response.text).toContain(en.back_to_your_companies);
+            expect(response.text).not.toContain(companyAssociations.items[0].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
+        });
+
+        it("should return expected Welsh content if person cancelled and language version set to Welsh", async () => {
+            // Given
+            const cancellation: Cancellation = {
+                cancelPerson: YES,
+                userEmail: companyAssociations.items[0].userEmail,
+                companyNumber: companyAssociations.items[0].companyNumber
+            };
+            const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+            expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== cancellation.userEmail);
+            getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+            sessionUtilsSpy.mockReturnValue(cancellation);
+            removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
+            // When
+            const response = await router.get(`${url}?lang=cy`);
+            // Then
+            expect(response.text).toContain(cyCommon.success);
+            expect(response.text).toContain(cy.digital_authorisation_cancelled);
+            expect(response.text).toContain(cy.you_have_successfully_cancelled_digital_authorisation_start);
+            expect(response.text).toContain(cy.you_have_successfully_cancelled_digital_authorisation_end);
+            expect(response.text).toContain(cy.weve_sent_an_email_to_the_company);
+            expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
+            expect(response.text).toContain(cy.people_digitally_authorised_to_file_online);
+            expect(response.text).toContain(cy.anyone_with_access_to_the_current_authentication);
+            expect(response.text).toContain(cy.add_new_authorised_person);
+            expect(response.text).toContain(cy.details_of_authorised_people);
+            expect(response.text).toContain(cy.email_address);
+            expect(response.text).toContain(cy.name);
+            expect(response.text).toContain(cy.status);
+            expect(response.text).toContain(cy.remove);
+            expect(response.text).toContain(cy.back_to_your_companies);
+            expect(response.text).not.toContain(companyAssociations.items[0].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
+        });
     });
 
-    it("should return status 200", async () => {
-        // Given
-        getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-        // When
-        const response = await router.get(url);
-        // Then
-        expect(response.status).toEqual(200);
-    });
+    describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-person-added", () => {
+        const companyNumber = "NI038379";
+        const url = `/your-companies/manage-authorised-people/${companyNumber}/confirmation-person-added`;
+        const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
+        const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
 
-    it("should return expected English content if language version set to English", async () => {
-        // Given
-        getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-        // When
-        const response = await router.get(`${url}?lang=en`);
-        // Then
-        expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
-        expect(response.text).toContain(en.people_digitally_authorised_to_file_online);
-        expect(response.text).toContain(en.anyone_with_access_to_the_current_authentication);
-        expect(response.text).toContain(en.add_new_authorised_person);
-        expect(response.text).toContain(en.details_of_authorised_people);
-        expect(response.text).toContain(en.email_address);
-        expect(response.text).toContain(en.name);
-        expect(response.text).toContain(en.status);
-        expect(response.text).toContain(en.remove);
-        expect(response.text).toContain(en.back_to_your_companies);
-        expect(response.text).not.toContain(enCommon.success);
-        expect(response.text).not.toContain(en.digital_authorisation_cancelled);
-        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
-    });
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
 
-    it("should return expected Welsh content if language version set to Welsh", async () => {
-        // Given
-        getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-        // When
-        const response = await router.get(`${url}?lang=cy`);
-        // Then
-        expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
-        expect(response.text).toContain(cy.people_digitally_authorised_to_file_online);
-        expect(response.text).toContain(cy.anyone_with_access_to_the_current_authentication);
-        expect(response.text).toContain(cy.add_new_authorised_person);
-        expect(response.text).toContain(cy.details_of_authorised_people);
-        expect(response.text).toContain(cy.email_address);
-        expect(response.text).toContain(cy.name);
-        expect(response.text).toContain(cy.status);
-        expect(response.text).toContain(cy.remove);
-        expect(response.text).toContain(cy.back_to_your_companies);
-        expect(response.text).not.toContain(cyCommon.success);
-        expect(response.text).not.toContain(cy.digital_authorisation_cancelled);
-        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
-    });
-});
-
-describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-cancel-person", () => {
-    const url = `/your-companies/manage-authorised-people/${companyNumber}/confirmation-cancel-person`;
-    const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
-    const removeUserFromCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "removeUserFromCompanyAssociations");
-    const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
-
-    beforeEach(() => {
-        jest.clearAllMocks();
-    });
-
-    it("should return expected English content if person cancelled and language version set to English", async () => {
-        // Given
-        const cancellation: Cancellation = {
-            cancelPerson: YES,
-            userEmail: companyAssociations.items[0].userEmail,
-            companyNumber: companyAssociations.items[0].companyNumber
+        const authorisedPerson: AuthorisedPerson = {
+            authorisedPersonEmailAddress: "bob@bob.com",
+            authorisedPersonCompanyName: "Acme Ltd"
         };
-        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
-        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== cancellation.userEmail);
-        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
-        sessionUtilsSpy.mockReturnValue(cancellation);
-        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
-        // When
-        const response = await router.get(`${url}?lang=en`);
-        // Then
-        expect(response.text).toContain(enCommon.success);
-        expect(response.text).toContain(en.digital_authorisation_cancelled);
-        expect(response.text).toContain(en.you_have_successfully_cancelled_digital_authorisation_start);
-        expect(response.text).toContain(en.you_have_successfully_cancelled_digital_authorisation_end);
-        expect(response.text).toContain(en.weve_sent_an_email_to_the_company);
-        expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
-        expect(response.text).toContain(en.people_digitally_authorised_to_file_online);
-        expect(response.text).toContain(en.anyone_with_access_to_the_current_authentication);
-        expect(response.text).toContain(en.add_new_authorised_person);
-        expect(response.text).toContain(en.details_of_authorised_people);
-        expect(response.text).toContain(en.email_address);
-        expect(response.text).toContain(en.name);
-        expect(response.text).toContain(en.status);
-        expect(response.text).toContain(en.remove);
-        expect(response.text).toContain(en.back_to_your_companies);
-        expect(response.text).not.toContain(companyAssociations.items[0].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
-    });
-
-    it("should return expected Welsh content if person cancelled and language version set to Welsh", async () => {
-        // Given
-        const cancellation: Cancellation = {
-            cancelPerson: YES,
-            userEmail: companyAssociations.items[0].userEmail,
-            companyNumber: companyAssociations.items[0].companyNumber
-        };
-        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
-        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== cancellation.userEmail);
-        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
-        sessionUtilsSpy.mockReturnValue(cancellation);
-        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
-        // When
-        const response = await router.get(`${url}?lang=cy`);
-        // Then
-        expect(response.text).toContain(cyCommon.success);
-        expect(response.text).toContain(cy.digital_authorisation_cancelled);
-        expect(response.text).toContain(cy.you_have_successfully_cancelled_digital_authorisation_start);
-        expect(response.text).toContain(cy.you_have_successfully_cancelled_digital_authorisation_end);
-        expect(response.text).toContain(cy.weve_sent_an_email_to_the_company);
-        expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
-        expect(response.text).toContain(cy.people_digitally_authorised_to_file_online);
-        expect(response.text).toContain(cy.anyone_with_access_to_the_current_authentication);
-        expect(response.text).toContain(cy.add_new_authorised_person);
-        expect(response.text).toContain(cy.details_of_authorised_people);
-        expect(response.text).toContain(cy.email_address);
-        expect(response.text).toContain(cy.name);
-        expect(response.text).toContain(cy.status);
-        expect(response.text).toContain(cy.remove);
-        expect(response.text).toContain(cy.back_to_your_companies);
-        expect(response.text).not.toContain(companyAssociations.items[0].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
-    });
-});
-
-describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-person-added", () => {
-    const companyNumber = "NI038379";
-    const url = `/your-companies/manage-authorised-people/${companyNumber}/confirmation-person-added`;
-    const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
-    const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
-
-    beforeEach(() => {
-        jest.clearAllMocks();
-    });
-
-    const authorisedPerson: AuthorisedPerson = {
-        authorisedPersonEmailAddress: "bob@bob.com",
-        authorisedPersonCompanyName: "Acme Ltd"
-    };
-    getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-
-    it("should check session and auth before returning the /your-companies/manage-authorised-people/NI038379/confirmation-person-added page", async () => {
+        // sessionUtilsSpy.mockReturnValue(authorisedPerson);
         getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-        await router.get(url);
-        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
-        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
-    });
 
-    it("should return status 200", async () => {
-        getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-        const response = await router.get(url);
-        expect(response.status).toEqual(200);
-    });
+        it("should check session and auth before returning the /your-companies/manage-authorised-people/NI038379/confirmation-person-added page", async () => {
+            getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+            await router.get(url);
+            expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+            expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
+        });
 
-    it("should return expected English content if language version set to English", async () => {
-        sessionUtilsSpy.mockReturnValue(authorisedPerson);
+        it("should return status 200", async () => {
+            getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+            const response = await router.get(url);
+            expect(response.status).toEqual(200);
+        });
 
-        const response = await router.get(`${url}?lang=en`);
-        expect(response.text).toContain(en.authorised_person_success_heading);
-        expect(response.text).toContain(en.authorised_person_success_msg1);
-        expect(response.text).toContain(en.authorised_person_success_msg2);
-        expect(response.text).toContain("Acme Ltd");
-        expect(response.text).toContain("bob@bob.com");
-    });
+        it("should return expected English content if language version set to English", async () => {
+            sessionUtilsSpy.mockReturnValue(authorisedPerson);
 
-    it("should return expected Welsh content if language version set to Welsh", async () => {
-        sessionUtilsSpy.mockReturnValue(authorisedPerson);
-        const response = await router.get(`${url}?lang=cy`);
-        expect(response.text).toContain(cy.authorised_person_success_heading);
-        expect(response.text).toContain(cy.authorised_person_success_msg1);
-        expect(response.text).toContain(cy.authorised_person_success_msg2);
-        expect(response.text).toContain("Acme Ltd");
-        expect(response.text).toContain("bob@bob.com");
-    });
-    it("should not display banner if no authorised person details saved in session", async () => {
-        sessionUtilsSpy.mockReturnValue(undefined);
-        const response = await router.get(`${url}?lang=en`);
-        expect(response.text.includes(en.authorised_person_success_heading)).toBe(false);
-        expect(response.text.includes("Acme Ltd")).toBe(false);
-        expect(response.text.includes("bob@bob.com")).toBe(false);
+            const response = await router.get(`${url}?lang=en`);
+            expect(response.text).toContain(en.authorised_person_success_heading);
+            expect(response.text).toContain(en.authorised_person_success_msg1);
+            expect(response.text).toContain(en.authorised_person_success_msg2);
+            expect(response.text).toContain("Acme Ltd");
+            expect(response.text).toContain("bob@bob.com");
+        });
+
+        it("should return expected Welsh content if language version set to Welsh", async () => {
+            sessionUtilsSpy.mockReturnValue(authorisedPerson);
+            const response = await router.get(`${url}?lang=cy`);
+            expect(response.text).toContain(cy.authorised_person_success_heading);
+            expect(response.text).toContain(cy.authorised_person_success_msg1);
+            expect(response.text).toContain(cy.authorised_person_success_msg2);
+            expect(response.text).toContain("Acme Ltd");
+            expect(response.text).toContain("bob@bob.com");
+        });
+        it("should not display banner if no authorised person details saved in session", async () => {
+            sessionUtilsSpy.mockReturnValue(undefined);
+            const response = await router.get(`${url}?lang=en`);
+            expect(response.text.includes(en.authorised_person_success_heading)).toBe(false);
+            expect(response.text.includes("Acme Ltd")).toBe(false);
+            expect(response.text.includes("bob@bob.com")).toBe(false);
+        });
     });
 
     describe("GET /your-companies/manage-authorised-people/:companyNumber/authorisation-email-resent", () => {
@@ -296,129 +297,129 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
             expect(response.text.includes("bob@bob.com")).toBe(false);
         });
     });
-});
 
-describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-person-removed", () => {
-    const url = `/your-companies/manage-authorised-people/${companyNumber}/confirmation-person-removed`;
-    const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
-    const removeUserFromCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "removeUserFromCompanyAssociations");
-    const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
+    describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-person-removed", () => {
+        const url = `/your-companies/manage-authorised-people/${companyNumber}/confirmation-person-removed`;
+        const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
+        const removeUserFromCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "removeUserFromCompanyAssociations");
+        const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-    });
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
 
-    it("should return expected English content if person removed, their name not provided and language version set to English", async () => {
-        // Given
-        const removal: Removal = {
-            removePerson: YES,
-            userEmail: companyAssociations.items[1].userEmail,
-            companyNumber: companyAssociations.items[1].companyNumber
-        };
-        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
-        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
-        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
-        const expectedBannerHeaderText = companyAssociations.items[1].userEmail + en.is_no_longer_digitally_authorised + companyAssociations.items[1].companyName;
-        sessionUtilsSpy.mockReturnValue(removal);
-        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
-        // When
-        const response = await router.get(`${url}?lang=en`);
-        // Then
-        expect(response.text).toContain(enCommon.success);
-        expect(response.text).toContain(expectedBannerHeaderText);
-        expect(response.text).toContain(en.weve_sent_an_email_to_the_company);
-        expect(response.text).toContain(en.you_may_wish_to);
-        expect(response.text).toContain(en.change_the_authentication_code);
-        expect(response.text).toContain(en.for_this_company_if + companyAssociations.items[1].userEmail + en.still_has_access_to_it);
-        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
-        expect(response.text).not.toContain(companyAssociations.items[1].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
-    });
+        it("should return expected English content if person removed, their name not provided and language version set to English", async () => {
+            // Given
+            const removal: Removal = {
+                removePerson: CONFIRM,
+                userEmail: companyAssociations.items[1].userEmail,
+                companyNumber: companyAssociations.items[1].companyNumber
+            };
+            const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+            expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
+            getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+            const expectedBannerHeaderText = companyAssociations.items[1].userEmail + en.is_no_longer_digitally_authorised + companyAssociations.items[1].companyName;
+            sessionUtilsSpy.mockReturnValue(removal);
+            removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
+            // When
+            const response = await router.get(`${url}?lang=en`);
+            // Then
+            expect(response.text).toContain(enCommon.success);
+            expect(response.text).toContain(expectedBannerHeaderText);
+            expect(response.text).toContain(en.weve_sent_an_email_to_the_company);
+            expect(response.text).toContain(en.you_may_wish_to);
+            expect(response.text).toContain(en.change_the_authentication_code);
+            expect(response.text).toContain(en.for_this_company_if + companyAssociations.items[1].userEmail + en.still_has_access_to_it);
+            expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+            expect(response.text).not.toContain(companyAssociations.items[1].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
+        });
 
-    it("should return expected Welsh content if person removed, their name not provided and language version set to Welsh", async () => {
-        // Given
-        const removal: Removal = {
-            removePerson: YES,
-            userEmail: companyAssociations.items[1].userEmail,
-            companyNumber: companyAssociations.items[1].companyNumber
-        };
-        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
-        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
-        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
-        const expectedBannerHeaderText = companyAssociations.items[1].userEmail + cy.is_no_longer_digitally_authorised + companyAssociations.items[1].companyName;
-        sessionUtilsSpy.mockReturnValue(removal);
-        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
-        // When
-        const response = await router.get(`${url}?lang=cy`);
-        // Then
-        expect(response.text).toContain(cyCommon.success);
-        expect(response.text).toContain(expectedBannerHeaderText);
-        expect(response.text).toContain(cy.weve_sent_an_email_to_the_company);
-        expect(response.text).toContain(cy.you_may_wish_to);
-        expect(response.text).toContain(cy.change_the_authentication_code);
-        expect(response.text).toContain(cy.for_this_company_if + companyAssociations.items[1].userEmail + cy.still_has_access_to_it);
-        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
-        expect(response.text).not.toContain(companyAssociations.items[1].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
-    });
+        it("should return expected Welsh content if person removed, their name not provided and language version set to Welsh", async () => {
+            // Given
+            const removal: Removal = {
+                removePerson: CONFIRM,
+                userEmail: companyAssociations.items[1].userEmail,
+                companyNumber: companyAssociations.items[1].companyNumber
+            };
+            const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+            expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
+            getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+            const expectedBannerHeaderText = companyAssociations.items[1].userEmail + cy.is_no_longer_digitally_authorised + companyAssociations.items[1].companyName;
+            sessionUtilsSpy.mockReturnValue(removal);
+            removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
+            // When
+            const response = await router.get(`${url}?lang=cy`);
+            // Then
+            expect(response.text).toContain(cyCommon.success);
+            expect(response.text).toContain(expectedBannerHeaderText);
+            expect(response.text).toContain(cy.weve_sent_an_email_to_the_company);
+            expect(response.text).toContain(cy.you_may_wish_to);
+            expect(response.text).toContain(cy.change_the_authentication_code);
+            expect(response.text).toContain(cy.for_this_company_if + companyAssociations.items[1].userEmail + cy.still_has_access_to_it);
+            expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+            expect(response.text).not.toContain(companyAssociations.items[1].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
+        });
 
-    it("should return expected English content if person removed, their name provided and language version set to English", async () => {
-        // Given
-        const removal: Removal = {
-            removePerson: YES,
-            userEmail: companyAssociations.items[3].userEmail,
-            userName: companyAssociations.items[3].displayName,
-            companyNumber: companyAssociations.items[3].companyNumber
-        };
-        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
-        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
-        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
-        const expectedBannerHeaderText = companyAssociations.items[3].displayName + en.is_no_longer_digitally_authorised + companyAssociations.items[3].companyName;
-        sessionUtilsSpy.mockReturnValue(removal);
-        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
-        // When
-        const response = await router.get(`${url}?lang=en`);
-        // Then
-        expect(response.text).toContain(enCommon.success);
-        expect(response.text).toContain(expectedBannerHeaderText);
-        expect(response.text).toContain(en.weve_sent_an_email_to_the_company);
-        expect(response.text).toContain(en.you_may_wish_to);
-        expect(response.text).toContain(en.change_the_authentication_code);
-        expect(response.text).toContain(en.for_this_company_if + companyAssociations.items[3].displayName + en.still_has_access_to_it);
-        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-        expect(response.text).not.toContain(companyAssociations.items[3].userEmail + "</th>");
-    });
+        it("should return expected English content if person removed, their name provided and language version set to English", async () => {
+            // Given
+            const removal: Removal = {
+                removePerson: CONFIRM,
+                userEmail: companyAssociations.items[3].userEmail,
+                userName: companyAssociations.items[3].displayName,
+                companyNumber: companyAssociations.items[3].companyNumber
+            };
+            const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+            expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
+            getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+            const expectedBannerHeaderText = companyAssociations.items[3].displayName + en.is_no_longer_digitally_authorised + companyAssociations.items[3].companyName;
+            sessionUtilsSpy.mockReturnValue(removal);
+            removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
+            // When
+            const response = await router.get(`${url}?lang=en`);
+            // Then
+            expect(response.text).toContain(enCommon.success);
+            expect(response.text).toContain(expectedBannerHeaderText);
+            expect(response.text).toContain(en.weve_sent_an_email_to_the_company);
+            expect(response.text).toContain(en.you_may_wish_to);
+            expect(response.text).toContain(en.change_the_authentication_code);
+            expect(response.text).toContain(en.for_this_company_if + companyAssociations.items[3].displayName + en.still_has_access_to_it);
+            expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+            expect(response.text).not.toContain(companyAssociations.items[3].userEmail + "</th>");
+        });
 
-    it("should return expected Welsh content if person removed, their name provided and language version set to Welsh", async () => {
-        // Given
-        const removal: Removal = {
-            removePerson: YES,
-            userEmail: companyAssociations.items[3].userEmail,
-            userName: companyAssociations.items[3].displayName,
-            companyNumber: companyAssociations.items[3].companyNumber
-        };
-        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
-        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
-        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
-        const expectedBannerHeaderText = companyAssociations.items[3].displayName + cy.is_no_longer_digitally_authorised + companyAssociations.items[3].companyName;
-        sessionUtilsSpy.mockReturnValue(removal);
-        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
-        // When
-        const response = await router.get(`${url}?lang=cy`);
-        // Then
-        expect(response.text).toContain(cyCommon.success);
-        expect(response.text).toContain(expectedBannerHeaderText);
-        expect(response.text).toContain(cy.weve_sent_an_email_to_the_company);
-        expect(response.text).toContain(cy.you_may_wish_to);
-        expect(response.text).toContain(cy.change_the_authentication_code);
-        expect(response.text).toContain(cy.for_this_company_if + companyAssociations.items[3].displayName + cy.still_has_access_to_it);
-        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
-        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-        expect(response.text).not.toContain(companyAssociations.items[3].userEmail + "</th>");
+        it("should return expected Welsh content if person removed, their name provided and language version set to Welsh", async () => {
+            // Given
+            const removal: Removal = {
+                removePerson: CONFIRM,
+                userEmail: companyAssociations.items[3].userEmail,
+                userName: companyAssociations.items[3].displayName,
+                companyNumber: companyAssociations.items[3].companyNumber
+            };
+            const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+            expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
+            getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+            const expectedBannerHeaderText = companyAssociations.items[3].displayName + cy.is_no_longer_digitally_authorised + companyAssociations.items[3].companyName;
+            sessionUtilsSpy.mockReturnValue(removal);
+            removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
+            // When
+            const response = await router.get(`${url}?lang=cy`);
+            // Then
+            expect(response.text).toContain(cyCommon.success);
+            expect(response.text).toContain(expectedBannerHeaderText);
+            expect(response.text).toContain(cy.weve_sent_an_email_to_the_company);
+            expect(response.text).toContain(cy.you_may_wish_to);
+            expect(response.text).toContain(cy.change_the_authentication_code);
+            expect(response.text).toContain(cy.for_this_company_if + companyAssociations.items[3].displayName + cy.still_has_access_to_it);
+            expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+            expect(response.text).not.toContain(companyAssociations.items[3].userEmail + "</th>");
+        });
     });
 });

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
@@ -11,6 +11,7 @@ import * as en from "../../../../src/locales/en/translation/manage-authorised-pe
 import * as cy from "../../../../src/locales/cy/translation/manage-authorised-people.json";
 import * as enCommon from "../../../../src/locales/en/translation/common.json";
 import * as cyCommon from "../../../../src/locales/cy/translation/common.json";
+import { Removal } from "../../../../src/types/removal";
 
 const router = supertest(app);
 
@@ -283,9 +284,109 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
     const removeUserFromCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "removeUserFromCompanyAssociations");
     const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
 
-    it("", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should return expected English content if person removed, their name not provided and language version set to English", async () => {
         // Given
+        const removal: Removal = {
+            removePerson: YES,
+            userEmail: companyAssociations.items[1].userEmail,
+            companyNumber: companyAssociations.items[1].companyNumber
+        };
+        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
+        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+        const expectedBannerHeaderText = companyAssociations.items[1].userEmail + en.is_no_longer_digitally_authorised + companyAssociations.items[1].companyName;
+        sessionUtilsSpy.mockReturnValue(removal);
+        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
         // When
+        const response = await router.get(`${url}?lang=en`);
         // Then
+        expect(response.text).toContain(enCommon.success);
+        expect(response.text).toContain(expectedBannerHeaderText);
+        expect(response.text).toContain(en.weve_sent_an_email_to_the_company);
+        expect(response.text).toContain(en.you_may_wish_to);
+        expect(response.text).toContain(en.change_the_authentication_code);
+        expect(response.text).toContain(en.for_this_company_if + companyAssociations.items[1].userEmail + en.still_has_access_to_it);
+        expect(response.text).not.toContain(companyAssociations.items[1].userEmail + "</th>");
+    });
+
+    it("should return expected Welsh content if person removed, their name not provided and language version set to Welsh", async () => {
+        // Given
+        const removal: Removal = {
+            removePerson: YES,
+            userEmail: companyAssociations.items[1].userEmail,
+            companyNumber: companyAssociations.items[1].companyNumber
+        };
+        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
+        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+        const expectedBannerHeaderText = companyAssociations.items[1].userEmail + cy.is_no_longer_digitally_authorised + companyAssociations.items[1].companyName;
+        sessionUtilsSpy.mockReturnValue(removal);
+        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
+        // When
+        const response = await router.get(`${url}?lang=cy`);
+        // Then
+        expect(response.text).toContain(cyCommon.success);
+        expect(response.text).toContain(expectedBannerHeaderText);
+        expect(response.text).toContain(cy.weve_sent_an_email_to_the_company);
+        expect(response.text).toContain(cy.you_may_wish_to);
+        expect(response.text).toContain(cy.change_the_authentication_code);
+        expect(response.text).toContain(cy.for_this_company_if + companyAssociations.items[1].userEmail + cy.still_has_access_to_it);
+        expect(response.text).not.toContain(companyAssociations.items[1].userEmail + "</th>");
+    });
+
+    it("should return expected English content if person removed, their name provided and language version set to English", async () => {
+        // Given
+        const removal: Removal = {
+            removePerson: YES,
+            userEmail: companyAssociations.items[3].userEmail,
+            userName: companyAssociations.items[3].displayName,
+            companyNumber: companyAssociations.items[3].companyNumber
+        };
+        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
+        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+        const expectedBannerHeaderText = companyAssociations.items[3].displayName + en.is_no_longer_digitally_authorised + companyAssociations.items[3].companyName;
+        sessionUtilsSpy.mockReturnValue(removal);
+        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
+        // When
+        const response = await router.get(`${url}?lang=en`);
+        // Then
+        expect(response.text).toContain(enCommon.success);
+        expect(response.text).toContain(expectedBannerHeaderText);
+        expect(response.text).toContain(en.weve_sent_an_email_to_the_company);
+        expect(response.text).toContain(en.you_may_wish_to);
+        expect(response.text).toContain(en.change_the_authentication_code);
+        expect(response.text).toContain(en.for_this_company_if + companyAssociations.items[3].displayName + en.still_has_access_to_it);
+        expect(response.text).not.toContain(companyAssociations.items[3].userEmail + "</th>");
+    });
+
+    it("should return expected Welsh content if person removed, their name provided and language version set to Welsh", async () => {
+        // Given
+        const removal: Removal = {
+            removePerson: YES,
+            userEmail: companyAssociations.items[3].userEmail,
+            userName: companyAssociations.items[3].displayName,
+            companyNumber: companyAssociations.items[3].companyNumber
+        };
+        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
+        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
+        const expectedBannerHeaderText = companyAssociations.items[3].displayName + cy.is_no_longer_digitally_authorised + companyAssociations.items[3].companyName;
+        sessionUtilsSpy.mockReturnValue(removal);
+        removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
+        // When
+        const response = await router.get(`${url}?lang=cy`);
+        // Then
+        expect(response.text).toContain(cyCommon.success);
+        expect(response.text).toContain(expectedBannerHeaderText);
+        expect(response.text).toContain(cy.weve_sent_an_email_to_the_company);
+        expect(response.text).toContain(cy.you_may_wish_to);
+        expect(response.text).toContain(cy.change_the_authentication_code);
+        expect(response.text).toContain(cy.for_this_company_if + companyAssociations.items[3].displayName + cy.still_has_access_to_it);
+        expect(response.text).not.toContain(companyAssociations.items[3].userEmail + "</th>");
     });
 });

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
@@ -27,8 +27,9 @@ jest.mock("../../../../src/lib/utils/sessionUtils", () => {
     };
 });
 
+const companyNumber = "NI038379";
+
 describe("GET /your-companies/manage-authorised-people/:companyNumber", () => {
-    const companyNumber = "NI038379";
     const url = `/your-companies/manage-authorised-people/${companyNumber}`;
     const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
     const removeUserFromCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "removeUserFromCompanyAssociations");
@@ -93,6 +94,17 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber", () => {
         expect(response.text).not.toContain(cyCommon.success);
         expect(response.text).not.toContain(cy.digital_authorisation_cancelled);
     });
+});
+
+describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-cancel-person", () => {
+    const url = `/your-companies/manage-authorised-people/${companyNumber}/confirmation-cancel-person`;
+    const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
+    const removeUserFromCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "removeUserFromCompanyAssociations");
+    const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
 
     it("should return expected English content if person cancelled and language version set to English", async () => {
         // Given
@@ -105,7 +117,7 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber", () => {
         sessionUtilsSpy.mockReturnValue(cancellation);
         removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
         // When
-        const response = await router.get(`${url}$/confirmation-cancel-person?lang=en`);
+        const response = await router.get(`${url}?lang=en`);
         // Then
         expect(response.text).toContain(enCommon.success);
         expect(response.text).toContain(en.digital_authorisation_cancelled);
@@ -135,7 +147,7 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber", () => {
         sessionUtilsSpy.mockReturnValue(cancellation);
         removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
         // When
-        const response = await router.get(`${url}$/confirmation-cancel-person?lang=cy`);
+        const response = await router.get(`${url}?lang=cy`);
         // Then
         expect(response.text).toContain(cyCommon.success);
         expect(response.text).toContain(cy.digital_authorisation_cancelled);
@@ -262,5 +274,18 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
             expect(response.text.includes(en.email_resent_success_success_msg1)).toBe(false);
             expect(response.text.includes("bob@bob.com")).toBe(false);
         });
+    });
+});
+
+describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-person-removed", () => {
+    const url = `/your-companies/manage-authorised-people/${companyNumber}/confirmation-person-removed`;
+    const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
+    const removeUserFromCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "removeUserFromCompanyAssociations");
+    const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
+
+    it("", () => {
+        // Given
+        // When
+        // Then
     });
 });

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
@@ -74,6 +74,10 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber", () => {
         expect(response.text).toContain(en.back_to_your_companies);
         expect(response.text).not.toContain(enCommon.success);
         expect(response.text).not.toContain(en.digital_authorisation_cancelled);
+        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
     });
 
     it("should return expected Welsh content if language version set to Welsh", async () => {
@@ -94,6 +98,10 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber", () => {
         expect(response.text).toContain(cy.back_to_your_companies);
         expect(response.text).not.toContain(cyCommon.success);
         expect(response.text).not.toContain(cy.digital_authorisation_cancelled);
+        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
     });
 });
 
@@ -109,12 +117,14 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
 
     it("should return expected English content if person cancelled and language version set to English", async () => {
         // Given
-        getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
         const cancellation: Cancellation = {
             cancelPerson: YES,
             userEmail: companyAssociations.items[0].userEmail,
             companyNumber: companyAssociations.items[0].companyNumber
         };
+        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== cancellation.userEmail);
+        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
         sessionUtilsSpy.mockReturnValue(cancellation);
         removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
         // When
@@ -135,16 +145,22 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
         expect(response.text).toContain(en.status);
         expect(response.text).toContain(en.remove);
         expect(response.text).toContain(en.back_to_your_companies);
+        expect(response.text).not.toContain(companyAssociations.items[0].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
     });
 
     it("should return expected Welsh content if person cancelled and language version set to Welsh", async () => {
         // Given
-        getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
         const cancellation: Cancellation = {
             cancelPerson: YES,
             userEmail: companyAssociations.items[0].userEmail,
             companyNumber: companyAssociations.items[0].companyNumber
         };
+        const expectedCompanyAssociations = Object.assign({}, companyAssociations);
+        expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== cancellation.userEmail);
+        getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
         sessionUtilsSpy.mockReturnValue(cancellation);
         removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
         // When
@@ -165,6 +181,10 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
         expect(response.text).toContain(cy.status);
         expect(response.text).toContain(cy.remove);
         expect(response.text).toContain(cy.back_to_your_companies);
+        expect(response.text).not.toContain(companyAssociations.items[0].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
     });
 });
 

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
@@ -3,15 +3,10 @@ import { companyAssociations } from "../../../mocks/associations.mock";
 import app from "../../../../src/app";
 import * as userCompanyAssociationService from "../../../../src/services/userCompanyAssociationService";
 import supertest from "supertest";
-import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
-import { Cancellation } from "../../../../src/types/cancellation";
-import { CONFIRM, USER_REMOVED_FROM_COMPANY_ASSOCIATIONS, YES } from "../../../../src/constants";
-import { AuthorisedPerson } from "../../../../src/types/associations";
 import * as en from "../../../../src/locales/en/translation/manage-authorised-people.json";
 import * as cy from "../../../../src/locales/cy/translation/manage-authorised-people.json";
 import * as enCommon from "../../../../src/locales/en/translation/common.json";
 import * as cyCommon from "../../../../src/locales/cy/translation/common.json";
-import { Removal } from "../../../../src/types/removal";
 
 const router = supertest(app);
 
@@ -30,396 +25,75 @@ jest.mock("../../../../src/lib/utils/sessionUtils", () => {
 
 const companyNumber = "NI038379";
 
-describe("Manage Authorised People Controller", () => {
-    describe("GET /your-companies/manage-authorised-people/:companyNumber", () => {
-        const url = `/your-companies/manage-authorised-people/${companyNumber}`;
-        const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
+describe("GET /your-companies/manage-authorised-people/:companyNumber", () => {
+    const url = `/your-companies/manage-authorised-people/${companyNumber}`;
+    const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
 
-        beforeEach(() => {
-            jest.clearAllMocks();
-        });
-
-        it("should check session and auth before returning the /your-companies/manage-authorised-people/NI038379 page", async () => {
-            getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-            await router.get(url);
-            expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
-            expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
-        });
-
-        it("should return status 200", async () => {
-            // Given
-            getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-            // When
-            const response = await router.get(url);
-            // Then
-            expect(response.status).toEqual(200);
-        });
-
-        it("should return expected English content if language version set to English", async () => {
-            // Given
-            getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-            // When
-            const response = await router.get(`${url}?lang=en`);
-            // Then
-            expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
-            expect(response.text).toContain(en.people_digitally_authorised_to_file_online);
-            expect(response.text).toContain(en.anyone_with_access_to_the_current_authentication);
-            expect(response.text).toContain(en.add_new_authorised_person);
-            expect(response.text).toContain(en.details_of_authorised_people);
-            expect(response.text).toContain(en.email_address);
-            expect(response.text).toContain(en.name);
-            expect(response.text).toContain(en.status);
-            expect(response.text).toContain(en.remove);
-            expect(response.text).toContain(en.back_to_your_companies);
-            expect(response.text).not.toContain(enCommon.success);
-            expect(response.text).not.toContain(en.digital_authorisation_cancelled);
-            expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
-        });
-
-        it("should return expected Welsh content if language version set to Welsh", async () => {
-            // Given
-            getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-            // When
-            const response = await router.get(`${url}?lang=cy`);
-            // Then
-            expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
-            expect(response.text).toContain(cy.people_digitally_authorised_to_file_online);
-            expect(response.text).toContain(cy.anyone_with_access_to_the_current_authentication);
-            expect(response.text).toContain(cy.add_new_authorised_person);
-            expect(response.text).toContain(cy.details_of_authorised_people);
-            expect(response.text).toContain(cy.email_address);
-            expect(response.text).toContain(cy.name);
-            expect(response.text).toContain(cy.status);
-            expect(response.text).toContain(cy.remove);
-            expect(response.text).toContain(cy.back_to_your_companies);
-            expect(response.text).not.toContain(cyCommon.success);
-            expect(response.text).not.toContain(cy.digital_authorisation_cancelled);
-            expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
-        });
+    beforeEach(() => {
+        jest.clearAllMocks();
     });
 
-    describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-cancel-person", () => {
-        const url = `/your-companies/manage-authorised-people/${companyNumber}/confirmation-cancel-person`;
-        const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
-        const removeUserFromCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "removeUserFromCompanyAssociations");
-        const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
-
-        beforeEach(() => {
-            jest.clearAllMocks();
-        });
-
-        it("should return expected English content if person cancelled and language version set to English", async () => {
-            // Given
-            const cancellation: Cancellation = {
-                cancelPerson: YES,
-                userEmail: companyAssociations.items[0].userEmail,
-                companyNumber: companyAssociations.items[0].companyNumber
-            };
-            const expectedCompanyAssociations = Object.assign({}, companyAssociations);
-            expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== cancellation.userEmail);
-            getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
-            sessionUtilsSpy.mockReturnValue(cancellation);
-            removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
-            // When
-            const response = await router.get(`${url}?lang=en`);
-            // Then
-            expect(response.text).toContain(enCommon.success);
-            expect(response.text).toContain(en.digital_authorisation_cancelled);
-            expect(response.text).toContain(en.you_have_successfully_cancelled_digital_authorisation_start);
-            expect(response.text).toContain(en.you_have_successfully_cancelled_digital_authorisation_end);
-            expect(response.text).toContain(en.weve_sent_an_email_to_the_company);
-            expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
-            expect(response.text).toContain(en.people_digitally_authorised_to_file_online);
-            expect(response.text).toContain(en.anyone_with_access_to_the_current_authentication);
-            expect(response.text).toContain(en.add_new_authorised_person);
-            expect(response.text).toContain(en.details_of_authorised_people);
-            expect(response.text).toContain(en.email_address);
-            expect(response.text).toContain(en.name);
-            expect(response.text).toContain(en.status);
-            expect(response.text).toContain(en.remove);
-            expect(response.text).toContain(en.back_to_your_companies);
-            expect(response.text).not.toContain(companyAssociations.items[0].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
-        });
-
-        it("should return expected Welsh content if person cancelled and language version set to Welsh", async () => {
-            // Given
-            const cancellation: Cancellation = {
-                cancelPerson: YES,
-                userEmail: companyAssociations.items[0].userEmail,
-                companyNumber: companyAssociations.items[0].companyNumber
-            };
-            const expectedCompanyAssociations = Object.assign({}, companyAssociations);
-            expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== cancellation.userEmail);
-            getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
-            sessionUtilsSpy.mockReturnValue(cancellation);
-            removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
-            // When
-            const response = await router.get(`${url}?lang=cy`);
-            // Then
-            expect(response.text).toContain(cyCommon.success);
-            expect(response.text).toContain(cy.digital_authorisation_cancelled);
-            expect(response.text).toContain(cy.you_have_successfully_cancelled_digital_authorisation_start);
-            expect(response.text).toContain(cy.you_have_successfully_cancelled_digital_authorisation_end);
-            expect(response.text).toContain(cy.weve_sent_an_email_to_the_company);
-            expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
-            expect(response.text).toContain(cy.people_digitally_authorised_to_file_online);
-            expect(response.text).toContain(cy.anyone_with_access_to_the_current_authentication);
-            expect(response.text).toContain(cy.add_new_authorised_person);
-            expect(response.text).toContain(cy.details_of_authorised_people);
-            expect(response.text).toContain(cy.email_address);
-            expect(response.text).toContain(cy.name);
-            expect(response.text).toContain(cy.status);
-            expect(response.text).toContain(cy.remove);
-            expect(response.text).toContain(cy.back_to_your_companies);
-            expect(response.text).not.toContain(companyAssociations.items[0].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
-        });
-    });
-
-    describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-person-added", () => {
-        const companyNumber = "NI038379";
-        const url = `/your-companies/manage-authorised-people/${companyNumber}/confirmation-person-added`;
-        const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
-        const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
-
-        beforeEach(() => {
-            jest.clearAllMocks();
-        });
-
-        const authorisedPerson: AuthorisedPerson = {
-            authorisedPersonEmailAddress: "bob@bob.com",
-            authorisedPersonCompanyName: "Acme Ltd"
-        };
-        // sessionUtilsSpy.mockReturnValue(authorisedPerson);
+    it("should check session and auth before returning the /your-companies/manage-authorised-people/NI038379 page", async () => {
         getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-
-        it("should check session and auth before returning the /your-companies/manage-authorised-people/NI038379/confirmation-person-added page", async () => {
-            getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-            await router.get(url);
-            expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
-            expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
-        });
-
-        it("should return status 200", async () => {
-            getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-            const response = await router.get(url);
-            expect(response.status).toEqual(200);
-        });
-
-        it("should return expected English content if language version set to English", async () => {
-            sessionUtilsSpy.mockReturnValue(authorisedPerson);
-
-            const response = await router.get(`${url}?lang=en`);
-            expect(response.text).toContain(en.authorised_person_success_heading);
-            expect(response.text).toContain(en.authorised_person_success_msg1);
-            expect(response.text).toContain(en.authorised_person_success_msg2);
-            expect(response.text).toContain("Acme Ltd");
-            expect(response.text).toContain("bob@bob.com");
-        });
-
-        it("should return expected Welsh content if language version set to Welsh", async () => {
-            sessionUtilsSpy.mockReturnValue(authorisedPerson);
-            const response = await router.get(`${url}?lang=cy`);
-            expect(response.text).toContain(cy.authorised_person_success_heading);
-            expect(response.text).toContain(cy.authorised_person_success_msg1);
-            expect(response.text).toContain(cy.authorised_person_success_msg2);
-            expect(response.text).toContain("Acme Ltd");
-            expect(response.text).toContain("bob@bob.com");
-        });
-        it("should not display banner if no authorised person details saved in session", async () => {
-            sessionUtilsSpy.mockReturnValue(undefined);
-            const response = await router.get(`${url}?lang=en`);
-            expect(response.text.includes(en.authorised_person_success_heading)).toBe(false);
-            expect(response.text.includes("Acme Ltd")).toBe(false);
-            expect(response.text.includes("bob@bob.com")).toBe(false);
-        });
+        await router.get(url);
+        expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+        expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
     });
 
-    describe("GET /your-companies/manage-authorised-people/:companyNumber/authorisation-email-resent", () => {
-        const companyNumber = "NI038379";
-        const url = `/your-companies/manage-authorised-people/${companyNumber}/authorisation-email-resent`;
-        const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
-        const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
-
-        beforeEach(() => {
-            jest.clearAllMocks();
-        });
-
-        const resentSuccessEmail = "bob@bob.com";
+    it("should return status 200", async () => {
+        // Given
         getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-
-        it("should check session and auth before returning the /your-companies/manage-authorised-people/NI038379/authorisation-email-resent page", async () => {
-            getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-            await router.get(url);
-            expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
-            expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
-        });
-
-        it("should return status 200", async () => {
-            getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
-            const response = await router.get(url);
-            expect(response.status).toEqual(200);
-        });
-
-        it("should return expected English content if language version set to English", async () => {
-            sessionUtilsSpy.mockReturnValue(resentSuccessEmail);
-
-            const response = await router.get(`${url}?lang=en`);
-            expect(response.text).toContain(en.authorised_person_success_heading);
-            expect(response.text).toContain(en.email_resent_success_success_msg1);
-            expect(response.text).toContain(en.email_resent_success_success_msg1);
-            expect(response.text).toContain("bob@bob.com");
-        });
-
-        it("should return expected Welsh content if language version set to Welsh", async () => {
-            sessionUtilsSpy.mockReturnValue(resentSuccessEmail);
-            const response = await router.get(`${url}?lang=cy`);
-            expect(response.text).toContain(cy.authorised_person_success_heading);
-            expect(response.text).toContain(cy.email_resent_success_success_msg1);
-            expect(response.text).toContain(cy.email_resent_success_success_msg1);
-            expect(response.text).toContain("bob@bob.com");
-        });
-        it("should not display banner if no authorised person details saved in session", async () => {
-            sessionUtilsSpy.mockReturnValue(undefined);
-            const response = await router.get(`${url}?lang=en`);
-            expect(response.text.includes(en.email_resent_success_success_msg1)).toBe(false);
-            expect(response.text.includes("bob@bob.com")).toBe(false);
-        });
+        // When
+        const response = await router.get(url);
+        // Then
+        expect(response.status).toEqual(200);
     });
 
-    describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmation-person-removed", () => {
-        const url = `/your-companies/manage-authorised-people/${companyNumber}/confirmation-person-removed`;
-        const getCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "getCompanyAssociations");
-        const removeUserFromCompanyAssociationsSpy: jest.SpyInstance = jest.spyOn(userCompanyAssociationService, "removeUserFromCompanyAssociations");
-        const sessionUtilsSpy: jest.SpyInstance = jest.spyOn(sessionUtils, "getExtraData");
+    it("should return expected English content if language version set to English", async () => {
+        // Given
+        getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+        // When
+        const response = await router.get(`${url}?lang=en`);
+        // Then
+        expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
+        expect(response.text).toContain(en.people_digitally_authorised_to_file_online);
+        expect(response.text).toContain(en.anyone_with_access_to_the_current_authentication);
+        expect(response.text).toContain(en.add_new_authorised_person);
+        expect(response.text).toContain(en.details_of_authorised_people);
+        expect(response.text).toContain(en.email_address);
+        expect(response.text).toContain(en.name);
+        expect(response.text).toContain(en.status);
+        expect(response.text).toContain(en.remove);
+        expect(response.text).toContain(en.back_to_your_companies);
+        expect(response.text).not.toContain(enCommon.success);
+        expect(response.text).not.toContain(en.digital_authorisation_cancelled);
+        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
+    });
 
-        beforeEach(() => {
-            jest.clearAllMocks();
-        });
-
-        it("should return expected English content if person removed, their name not provided and language version set to English", async () => {
-            // Given
-            const removal: Removal = {
-                removePerson: CONFIRM,
-                userEmail: companyAssociations.items[1].userEmail,
-                companyNumber: companyAssociations.items[1].companyNumber
-            };
-            const expectedCompanyAssociations = Object.assign({}, companyAssociations);
-            expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
-            getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
-            const expectedBannerHeaderText = companyAssociations.items[1].userEmail + en.is_no_longer_digitally_authorised + companyAssociations.items[1].companyName;
-            sessionUtilsSpy.mockReturnValue(removal);
-            removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
-            // When
-            const response = await router.get(`${url}?lang=en`);
-            // Then
-            expect(response.text).toContain(enCommon.success);
-            expect(response.text).toContain(expectedBannerHeaderText);
-            expect(response.text).toContain(en.weve_sent_an_email_to_the_company);
-            expect(response.text).toContain(en.you_may_wish_to);
-            expect(response.text).toContain(en.change_the_authentication_code);
-            expect(response.text).toContain(en.for_this_company_if + companyAssociations.items[1].userEmail + en.still_has_access_to_it);
-            expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
-            expect(response.text).not.toContain(companyAssociations.items[1].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
-        });
-
-        it("should return expected Welsh content if person removed, their name not provided and language version set to Welsh", async () => {
-            // Given
-            const removal: Removal = {
-                removePerson: CONFIRM,
-                userEmail: companyAssociations.items[1].userEmail,
-                companyNumber: companyAssociations.items[1].companyNumber
-            };
-            const expectedCompanyAssociations = Object.assign({}, companyAssociations);
-            expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
-            getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
-            const expectedBannerHeaderText = companyAssociations.items[1].userEmail + cy.is_no_longer_digitally_authorised + companyAssociations.items[1].companyName;
-            sessionUtilsSpy.mockReturnValue(removal);
-            removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
-            // When
-            const response = await router.get(`${url}?lang=cy`);
-            // Then
-            expect(response.text).toContain(cyCommon.success);
-            expect(response.text).toContain(expectedBannerHeaderText);
-            expect(response.text).toContain(cy.weve_sent_an_email_to_the_company);
-            expect(response.text).toContain(cy.you_may_wish_to);
-            expect(response.text).toContain(cy.change_the_authentication_code);
-            expect(response.text).toContain(cy.for_this_company_if + companyAssociations.items[1].userEmail + cy.still_has_access_to_it);
-            expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
-            expect(response.text).not.toContain(companyAssociations.items[1].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
-        });
-
-        it("should return expected English content if person removed, their name provided and language version set to English", async () => {
-            // Given
-            const removal: Removal = {
-                removePerson: CONFIRM,
-                userEmail: companyAssociations.items[3].userEmail,
-                userName: companyAssociations.items[3].displayName,
-                companyNumber: companyAssociations.items[3].companyNumber
-            };
-            const expectedCompanyAssociations = Object.assign({}, companyAssociations);
-            expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
-            getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
-            const expectedBannerHeaderText = companyAssociations.items[3].displayName + en.is_no_longer_digitally_authorised + companyAssociations.items[3].companyName;
-            sessionUtilsSpy.mockReturnValue(removal);
-            removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
-            // When
-            const response = await router.get(`${url}?lang=en`);
-            // Then
-            expect(response.text).toContain(enCommon.success);
-            expect(response.text).toContain(expectedBannerHeaderText);
-            expect(response.text).toContain(en.weve_sent_an_email_to_the_company);
-            expect(response.text).toContain(en.you_may_wish_to);
-            expect(response.text).toContain(en.change_the_authentication_code);
-            expect(response.text).toContain(en.for_this_company_if + companyAssociations.items[3].displayName + en.still_has_access_to_it);
-            expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-            expect(response.text).not.toContain(companyAssociations.items[3].userEmail + "</th>");
-        });
-
-        it("should return expected Welsh content if person removed, their name provided and language version set to Welsh", async () => {
-            // Given
-            const removal: Removal = {
-                removePerson: CONFIRM,
-                userEmail: companyAssociations.items[3].userEmail,
-                userName: companyAssociations.items[3].displayName,
-                companyNumber: companyAssociations.items[3].companyNumber
-            };
-            const expectedCompanyAssociations = Object.assign({}, companyAssociations);
-            expectedCompanyAssociations.items = companyAssociations.items.filter(item => item.userEmail !== removal.userEmail);
-            getCompanyAssociationsSpy.mockReturnValue(expectedCompanyAssociations);
-            const expectedBannerHeaderText = companyAssociations.items[3].displayName + cy.is_no_longer_digitally_authorised + companyAssociations.items[3].companyName;
-            sessionUtilsSpy.mockReturnValue(removal);
-            removeUserFromCompanyAssociationsSpy.mockReturnValue(USER_REMOVED_FROM_COMPANY_ASSOCIATIONS);
-            // When
-            const response = await router.get(`${url}?lang=cy`);
-            // Then
-            expect(response.text).toContain(cyCommon.success);
-            expect(response.text).toContain(expectedBannerHeaderText);
-            expect(response.text).toContain(cy.weve_sent_an_email_to_the_company);
-            expect(response.text).toContain(cy.you_may_wish_to);
-            expect(response.text).toContain(cy.change_the_authentication_code);
-            expect(response.text).toContain(cy.for_this_company_if + companyAssociations.items[3].displayName + cy.still_has_access_to_it);
-            expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
-            expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
-            expect(response.text).not.toContain(companyAssociations.items[3].userEmail + "</th>");
-        });
+    it("should return expected Welsh content if language version set to Welsh", async () => {
+        // Given
+        getCompanyAssociationsSpy.mockReturnValue(companyAssociations);
+        // When
+        const response = await router.get(`${url}?lang=cy`);
+        // Then
+        expect(response.text).toContain(`${companyAssociations.items[0].companyName} (${companyAssociations.items[0].companyNumber})`);
+        expect(response.text).toContain(cy.people_digitally_authorised_to_file_online);
+        expect(response.text).toContain(cy.anyone_with_access_to_the_current_authentication);
+        expect(response.text).toContain(cy.add_new_authorised_person);
+        expect(response.text).toContain(cy.details_of_authorised_people);
+        expect(response.text).toContain(cy.email_address);
+        expect(response.text).toContain(cy.name);
+        expect(response.text).toContain(cy.status);
+        expect(response.text).toContain(cy.remove);
+        expect(response.text).toContain(cy.back_to_your_companies);
+        expect(response.text).not.toContain(cyCommon.success);
+        expect(response.text).not.toContain(cy.digital_authorisation_cancelled);
+        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
     });
 });

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
@@ -310,7 +310,10 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
         expect(response.text).toContain(en.you_may_wish_to);
         expect(response.text).toContain(en.change_the_authentication_code);
         expect(response.text).toContain(en.for_this_company_if + companyAssociations.items[1].userEmail + en.still_has_access_to_it);
+        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
         expect(response.text).not.toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
     });
 
     it("should return expected Welsh content if person removed, their name not provided and language version set to Welsh", async () => {
@@ -335,7 +338,10 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
         expect(response.text).toContain(cy.you_may_wish_to);
         expect(response.text).toContain(cy.change_the_authentication_code);
         expect(response.text).toContain(cy.for_this_company_if + companyAssociations.items[1].userEmail + cy.still_has_access_to_it);
+        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
         expect(response.text).not.toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[3].userEmail + "</th>");
     });
 
     it("should return expected English content if person removed, their name provided and language version set to English", async () => {
@@ -361,6 +367,9 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
         expect(response.text).toContain(en.you_may_wish_to);
         expect(response.text).toContain(en.change_the_authentication_code);
         expect(response.text).toContain(en.for_this_company_if + companyAssociations.items[3].displayName + en.still_has_access_to_it);
+        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
         expect(response.text).not.toContain(companyAssociations.items[3].userEmail + "</th>");
     });
 
@@ -387,6 +396,9 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber/confirmati
         expect(response.text).toContain(cy.you_may_wish_to);
         expect(response.text).toContain(cy.change_the_authentication_code);
         expect(response.text).toContain(cy.for_this_company_if + companyAssociations.items[3].displayName + cy.still_has_access_to_it);
+        expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[1].userEmail + "</th>");
+        expect(response.text).toContain(companyAssociations.items[2].userEmail + "</th>");
         expect(response.text).not.toContain(companyAssociations.items[3].userEmail + "</th>");
     });
 });

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
@@ -64,7 +64,7 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber", () => {
         expect(response.text).toContain(en.name);
         expect(response.text).toContain(en.status);
         expect(response.text).toContain(en.remove);
-        expect(response.text).toContain(en.back_to_your_companies);
+        expect(response.text).toContain(en.go_back_to_your_companies);
         expect(response.text).not.toContain(enCommon.success);
         expect(response.text).not.toContain(en.digital_authorisation_cancelled);
         expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");
@@ -88,7 +88,7 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber", () => {
         expect(response.text).toContain(cy.name);
         expect(response.text).toContain(cy.status);
         expect(response.text).toContain(cy.remove);
-        expect(response.text).toContain(cy.back_to_your_companies);
+        expect(response.text).toContain(cy.go_back_to_your_companies);
         expect(response.text).not.toContain(cyCommon.success);
         expect(response.text).not.toContain(cy.digital_authorisation_cancelled);
         expect(response.text).toContain(companyAssociations.items[0].userEmail + "</th>");


### PR DESCRIPTION
Link to Jira:
https://companieshouse.atlassian.net/browse/IDVA6-368

Changes:
- Manage authorised people page updated to display success banner on person removal
- Problems with debugger fixed
- Test updated and new added