### PR TITLE
IDVA6-699 - Accept and Decline invitations

### DIFF
--- a/src/lib/helpers/invitationHelper.ts
+++ b/src/lib/helpers/invitationHelper.ts
@@ -1,0 +1,6 @@
+import { Invitation } from "../../types/associations";
+
+export const getNewestInvite = (associations: Invitation[]):Invitation => {
+    return associations.reduce((a, b) =>
+        new Date(a.invitedAt) > new Date(b.invitedAt) ? a : b);
+};

--- a/src/lib/helpers/invitationHelper.ts
+++ b/src/lib/helpers/invitationHelper.ts
@@ -1,6 +1,6 @@
 import { Invitation } from "../../types/associations";
 
-export const getNewestInvite = (associations: Invitation[]):Invitation => {
-    return associations.reduce((a, b) =>
+export const getNewestInvite = (invitations: Invitation[]):Invitation => {
+    return invitations.reduce((a, b) =>
         new Date(a.invitedAt) > new Date(b.invitedAt) ? a : b);
 };

--- a/src/lib/helpers/invitationHelper.ts
+++ b/src/lib/helpers/invitationHelper.ts
@@ -1,4 +1,4 @@
-import { Invitation } from "../../types/associations";
+import { Invitation } from "private-api-sdk-node/dist/services/associations/types";
 
 export const getNewestInvite = (invitations: Invitation[]):Invitation => {
     return invitations.reduce((a, b) =>

--- a/src/routers/handlers/yourCompanies/companyInvitationsHandler.ts
+++ b/src/routers/handlers/yourCompanies/companyInvitationsHandler.ts
@@ -29,11 +29,7 @@ export class CompanyInvitationsHandler extends GenericHandler {
         const rows: ({ text: string } | { html: string })[][] = [];
         if (userAssociations?.length) {
             for (const association of userAssociations) {
-                // { "invited_by": "6666", "invited_at": "2024-04-08T17:27:19.539917" }
                 if (association.invitations?.length) {
-                    // for (const invite of association.invitations) {
-                    // const newestInvite = association.invitations.reduce((a, b) =>
-                    //     new Date(a.invitedAt) > new Date(b.invitedAt) ? b : a);
                     const newestInvite = getNewestInvite(association.invitations);
                     const acceptPath = constants.YOUR_COMPANIES_COMPANY_INVITATIONS_ACCEPT_URL.replace(`:${constants.ASSOCIATIONS_ID}`, association.id);
                     const declinePath = constants.YOUR_COMPANIES_COMPANY_INVITATIONS_DECLINE_URL.replace(`:${constants.ASSOCIATIONS_ID}`, association.id);
@@ -41,7 +37,7 @@ export class CompanyInvitationsHandler extends GenericHandler {
                     rows.push([
                         { text: association.companyName },
                         { text: association.companyNumber },
-                        { text: newestInvite?.invitedBy },
+                        { text: newestInvite.invitedBy },
                         {
                             html: this.getLink(acceptPath + companyNameQueryParam, `${translations.accept_an_invitation_from} ${association.companyName}`, translations.accept as string)
                         },
@@ -49,7 +45,6 @@ export class CompanyInvitationsHandler extends GenericHandler {
                             html: this.getLink(declinePath + companyNameQueryParam, `${translations.decline_an_invitation_from} ${association.companyName}`, translations.decline as string)
                         }
                     ]);
-                    //   } // end for (const invite of association.invitations
                 }
             }
         }

--- a/src/types/associations.ts
+++ b/src/types/associations.ts
@@ -1,8 +1,3 @@
-export interface Invitation {
-    invitedBy: string;
-    invitedAt: string;
-}
-
 export type AuthorisedPerson = {
     authorisedPersonCompanyName: string,
     authorisedPersonEmailAddress: string,

--- a/src/types/associations.ts
+++ b/src/types/associations.ts
@@ -1,6 +1,6 @@
 export interface Invitation {
     invitedBy: string;
-    invitedAy: string;
+    invitedAt: string;
 }
 
 export type AuthorisedPerson = {

--- a/test/src/lib/helpers/invitationHelper.test.ts
+++ b/test/src/lib/helpers/invitationHelper.test.ts
@@ -1,5 +1,5 @@
 import { getNewestInvite } from "../../../../src/lib/helpers/invitationHelper";
-import { Invitation } from "../../../../src/types/associations";
+import { Invitation } from "private-api-sdk-node/dist/services/associations/types";
 
 describe("getNewestInvite", () => {
     it("should return the most recent invitation", () => {

--- a/test/src/lib/helpers/invitationHelper.test.ts
+++ b/test/src/lib/helpers/invitationHelper.test.ts
@@ -1,0 +1,40 @@
+import { getNewestInvite } from "../../../../src/lib/helpers/invitationHelper";
+import { Invitation } from "../../../../src/types/associations";
+
+describe("getNewestInvite", () => {
+    it("should return the most recent invitation", () => {
+        // Given
+        const inviteNew:Invitation = { invitedBy: "11", invitedAt: "2024-04-08T17:27:19.539917" };
+        const inviteOld:Invitation = { invitedBy: "22", invitedAt: "2024-03-15T17:23:40.225089" };
+
+        const invitationsArray:Invitation[] = [inviteNew, inviteOld];
+        // When
+        const result = getNewestInvite(invitationsArray);
+        // Then
+        expect(result).toEqual(inviteNew);
+    });
+    it("should return the most recent invitation", () => {
+        // Given
+        const invite1:Invitation = { invitedBy: "1", invitedAt: "2024-04-08T17:27:19.539917" };
+        const invite2:Invitation = { invitedBy: "2", invitedAt: "2024-03-15T17:23:40.225089" };
+        const invite3:Invitation = { invitedBy: "3", invitedAt: "2024-01-15T17:23:40.225089" };
+        const invite4:Invitation = { invitedBy: "4", invitedAt: "2024-04-22T17:23:40.225089" };
+        const invite5:Invitation = { invitedBy: "5", invitedAt: "2024-04-15T17:23:40.225089" };
+
+        const invitationsArray:Invitation[] = [invite1, invite2, invite3, invite4, invite5];
+        // When
+        const result = getNewestInvite(invitationsArray);
+        // Then
+        expect(result).toEqual(invite4);
+    });
+    it("should return the only invitation", () => {
+        // Given
+        const singleInvite:Invitation = { invitedBy: "1", invitedAt: "2024-04-08T17:27:19.539917" };
+
+        const invitationsArray:Invitation[] = [singleInvite];
+        // When
+        const result = getNewestInvite(invitationsArray);
+        // Then
+        expect(result).toEqual(singleInvite);
+    });
+});


### PR DESCRIPTION
Link to Jira:
https://companieshouse.atlassian.net/browse/IDVA6-699

Changes:

- In cases where there are multiples invites for a single association, this PR updates the invitations controller so that one invite is displayed per company / association. The most recent invite details will be displayed for each association.