### PR TITLE
IDVA6-1082 - adding back link analytics tracking for required pages

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -75,6 +75,7 @@ app.use((req: Request, res: Response, next: NextFunction) => {
     njk.addGlobal("addLangToUrl", (lang: string) => addLangToUrl(req.originalUrl, lang));
     njk.addGlobal("matomoButtonClick", constants.MATOMO_BUTTON_CLICK);
     njk.addGlobal("matomoLinkClick", constants.MATOMO_LINK_CLICK);
+    njk.addGlobal("matomoBackLink", constants.MATOMO_BACK_LINK);
     next();
 });
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -167,6 +167,7 @@ export const MATOMO_ACCEPT_INVITATION_LINK = "Accept Authorised User Invitation 
 export const MATOMO_DECLINE_INVITATION_LINK = "Decline Authorised User Invitation Link";
 export const MATOMO_ADD_COMPANY_GOAL_ID = getEnvironmentValue("MATOMO_ADD_COMPANY_GOAL_ID");
 export const MATOMO_ADD_NEW_AUTHORISED_PERSON_GOAL_ID = getEnvironmentValue("MATOMO_ADD_NEW_AUTHORISED_PERSON_GOAL_ID");
+export const MATOMO_BACK_LINK = "Back Link";
 
 // various
 export const NOT_PROVIDED = "Not provided";

--- a/src/views/add-company.njk
+++ b/src/views/add-company.njk
@@ -18,11 +18,7 @@
 {% endfor %}
 
 {% block back_link %}
-
-    <div role="navigation" aria-label="{{lang.link_back_to_previous_page}}">
-        {{ govukBackLink({text: lang.back_link, href: backLinkHref }) }}
-    </div>
-
+    {% include "partials/back_link.njk" %}
 {% endblock %}
 
 {% block main_content %}
@@ -66,6 +62,7 @@
 
     <script>
         trackEvent("continue-button", "{{title}}", "{{matomoButtonClick}}", "{{matomoContinueButton}}");
+        trackEvent("back-link-to-previous-page", "{{title}}", "{{matomoLinkClick}}", "{{matomoBackLink}}");
     </script>
 
 {% endblock %}

--- a/src/views/add-presenter-check-details.njk
+++ b/src/views/add-presenter-check-details.njk
@@ -66,5 +66,6 @@
     <script>
         trackEvent("confirm-and-send-email-button", "{{lang.title}}", "{{matomoButtonClick}}", "{{matomoConfirmAndSendEmailButton}}");
         trackEvent("change-link", "{{lang.title}}", "{{matomoLinkClick}}", "{{matomoChangeLink}}");
+        trackEvent("back-link-to-previous-page", "{{lang.title}}", "{{matomoLinkClick}}", "{{matomoBackLink}}");
     </script>
 {% endblock %}

--- a/src/views/add-presenter.njk
+++ b/src/views/add-presenter.njk
@@ -67,5 +67,6 @@
 
     <script>
         trackEvent("continue-button", "{{title}}", "{{matomoButtonClick}}", "{{matomoContinueButton}}");
+        trackEvent("back-link-to-previous-page", "{{title}}", "{{matomoLinkClick}}", "{{matomoBackLink}}");
     </script>
 {% endblock %}

--- a/src/views/cancel-person.njk
+++ b/src/views/cancel-person.njk
@@ -5,12 +5,9 @@
 
 {% extends "layouts/default.njk" %}
 {% set title = lang.are_you_sure_you_want_to_cancel_start + userEmail + lang.are_you_sure_you_want_to_cancel_end + lang.title_end %}
+
 {% block back_link %}
-
-    <div role="navigation" aria-label="{{lang.link_back_to_previous_page}}">
-        {{ govukBackLink({text: lang.back_link, href: backLinkHref }) }}
-    </div>
-
+    {% include "partials/back_link.njk" %}
 {% endblock %}
 
 {% set message = null %}
@@ -93,5 +90,6 @@
         }
 
         trackEvent("cancel-link", "{{title}}", "{{matomoLinkClick}}", "{{matomoCancelLink}}");
+        trackEvent("back-link-to-previous-page", "{{title}}", "{{matomoLinkClick}}", "{{matomoBackLink}}");
     </script>
 {% endblock %}

--- a/src/views/company-invitations.njk
+++ b/src/views/company-invitations.njk
@@ -5,12 +5,9 @@
 {% extends "layouts/default.njk" %}
 
 {% block back_link %}
-
-    <div role="navigation" aria-label="{{lang.link_back_to_previous_page}}">
-        {{ govukBackLink({text: lang.back_to_your_companies, href: backLinkHref }) }}
-    </div>
-
+    {% include "partials/back_link.njk" %}
 {% endblock %}
+
 {% block main_content %}
 
     {% set acceptHeader %}
@@ -78,6 +75,8 @@
             let subVarJ = declineIdArray[j]
                 trackEvent(subVarJ, "{{lang.title}}", "{{matomoLinkClick}}", "{{matomoDeclineAuthorisedUserInvitationLink}}");
         }
+
+        trackEvent("back-link-to-previous-page", "{{lang.title}}", "{{matomoLinkClick}}", "{{matomoBackLink}}");
 
     </script>
 

--- a/src/views/confirm-company-details.njk
+++ b/src/views/confirm-company-details.njk
@@ -89,5 +89,6 @@
 
     <script>
         trackEvent("submit", "{{lang.title}}", "{{matomoButtonClick}}", "{{matomoConfirmAndContinueButton}}");
+        trackEvent("back-link-to-previous-page", "{{lang.title}}", "{{matomoLinkClick}}", "{{matomoBackLink}}");
     </script>
 {% endblock %}

--- a/src/views/manage-authorised-people.njk
+++ b/src/views/manage-authorised-people.njk
@@ -17,7 +17,7 @@
     <div role="navigation" aria-label="{{lang.link_back_to_previous_page}}">
         {{ govukBackLink({text: lang.go_back_to_your_companies, href: backLinkHref }) }}
     </div>
-
+    
 {% endblock %}
 
 {% block main_content %}
@@ -201,6 +201,7 @@
         if (document.getElementById("change-company-auth-code-link")) {
             trackEvent("change-company-auth-code-link", "{{title}}", "{{matomoLinkClick}}", "{{matomoChangeTheAuthenticationCodeLink}}");
         }
+        trackEvent("back-link-to-previous-page", "{{title}}", "{{matomoLinkClick}}", "{{matomoBackLink}}");
     </script>
 
 {% endblock %}

--- a/src/views/partials/back_link.njk
+++ b/src/views/partials/back_link.njk
@@ -1,5 +1,8 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
     <div role="navigation" aria-label="back link to previous page">
-        {{ govukBackLink({text: lang.back_link, href: backLinkHref }) }}
+        {{ govukBackLink({text: lang.back_link, href: backLinkHref, attributes: {
+                id: "back-link-to-previous-page",
+                "data-event-id": "back-link-to-previous-page-event"
+            } }) }}
     </div>

--- a/src/views/remove-authorised-person.njk
+++ b/src/views/remove-authorised-person.njk
@@ -10,9 +10,7 @@
 {% set title = lang.remove + user_details + lang.authorisation_to_file_online + lang.title_end %}
 
 {% block back_link %}
-    <div role="navigation" aria-label="{{lang.link_back_to_previous_page}}">
-        {{ govukBackLink({text: lang.back_link, href: backLinkHref }) }}
-    </div>
+    {% include "partials/back_link.njk" %}  
 {% endblock %}
 
 {% set message = null %}
@@ -89,5 +87,6 @@
     <script>
         trackEvent("remove-authorisation-button", "{{title}}", "{{matomoButtonClick}}", "{{matomoRemoveAuthorisationButton}}");
         trackEvent("cancel-link", "{{title}}", "{{matomoLinkClick}}", "{{matomoCancelLink}}");
+        trackEvent("back-link-to-previous-page", "{{title}}", "{{matomoLinkClick}}", "{{matomoBackLink}}");
     </script>
 {% endblock %}


### PR DESCRIPTION
Link to Jira:
https://companieshouse.atlassian.net/browse/IDVA6-1082

Changes:
- Added matomo track events for back links on required pages
- Updated back_link.njk to include id and event id for matomo tracking
- Updated njk files to 'include' the back_link.njk
