### PR TITLE
IDVA6-1397: Integrate CH Node Utils for navbar and translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@braintree/sanitize-url": "^7.0.1",
         "@companieshouse/api-sdk-node": "^2.0.160",
+        "@companieshouse/ch-node-utils": "^1.3.7",
         "@companieshouse/node-session-handler": "^5.0.2",
         "@companieshouse/structured-logging-node": "^2.0.1",
         "@companieshouse/web-security-node": "^4.1.1",
@@ -617,6 +618,19 @@
         "http-status-codes": "^2.3.0",
         "snakecase-keys": "~3.2.0",
         "url-search-params-polyfill": "~8.1.1"
+      }
+    },
+    "node_modules/@companieshouse/ch-node-utils": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@companieshouse/ch-node-utils/-/ch-node-utils-1.3.7.tgz",
+      "integrity": "sha512-TqwivgZZyJKdzTomTTbaeqztLCLJpfDLwOyViKM3acRPZqbK5VdfF9fpHHGKhpEKqk09WWUQWhE/tH8GyU+UiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@companieshouse/node-session-handler": "^5.0.1",
+        "express": "^4.18.3",
+        "i18next": "^23.10.1",
+        "i18next-fs-backend": "^2.3.1",
+        "iso-639-1": "^3.1.2"
       }
     },
     "node_modules/@companieshouse/node-session-handler": {
@@ -6333,6 +6347,12 @@
         "@babel/runtime": "^7.23.2"
       }
     },
+    "node_modules/i18next-fs-backend": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.3.2.tgz",
+      "integrity": "sha512-LIwUlkqDZnUI8lnUxBnEj8K/FrHQTT/Sc+1rvDm9E8YvvY5YxzoEAASNx+W5M9DfD5s77lI5vSAFWeTp26B/3Q==",
+      "license": "MIT"
+    },
     "node_modules/i18next-http-middleware": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/i18next-http-middleware/-/i18next-http-middleware-3.6.0.tgz",
@@ -7005,6 +7025,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/iso-639-1": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/iso-639-1/-/iso-639-1-3.1.2.tgz",
+      "integrity": "sha512-Le7BRl3Jt9URvaiEHJCDEdvPZCfhiQoXnFgLAWNRhzFMwRFdWO7/5tLRQbiPzE394I9xd7KdRCM7S6qdOhwG5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/isobject": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@braintree/sanitize-url": "^7.0.1",
         "@companieshouse/api-sdk-node": "^2.0.160",
-        "@companieshouse/ch-node-utils": "^1.3.7",
+        "@companieshouse/ch-node-utils": "^1.3.8",
         "@companieshouse/node-session-handler": "^5.0.2",
         "@companieshouse/structured-logging-node": "^2.0.1",
         "@companieshouse/web-security-node": "^4.1.1",
@@ -621,9 +621,9 @@
       }
     },
     "node_modules/@companieshouse/ch-node-utils": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@companieshouse/ch-node-utils/-/ch-node-utils-1.3.7.tgz",
-      "integrity": "sha512-TqwivgZZyJKdzTomTTbaeqztLCLJpfDLwOyViKM3acRPZqbK5VdfF9fpHHGKhpEKqk09WWUQWhE/tH8GyU+UiA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@companieshouse/ch-node-utils/-/ch-node-utils-1.3.8.tgz",
+      "integrity": "sha512-FwlIUi01EnZsjSM1XypX5XIixhnr0xwzZjwsLsJ25/vaOnKL0fct7M1+hXmBUAXtx3JaFPcmXmYzw/pE6PK5sQ==",
       "license": "MIT",
       "dependencies": {
         "@companieshouse/node-session-handler": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@braintree/sanitize-url": "^7.0.1",
     "@companieshouse/api-sdk-node": "^2.0.160",
+    "@companieshouse/ch-node-utils": "^1.3.7",
     "@companieshouse/node-session-handler": "^5.0.2",
     "@companieshouse/structured-logging-node": "^2.0.1",
     "@companieshouse/web-security-node": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@braintree/sanitize-url": "^7.0.1",
     "@companieshouse/api-sdk-node": "^2.0.160",
-    "@companieshouse/ch-node-utils": "^1.3.7",
+    "@companieshouse/ch-node-utils": "^1.3.8",
     "@companieshouse/node-session-handler": "^5.0.2",
     "@companieshouse/structured-logging-node": "^2.0.1",
     "@companieshouse/web-security-node": "^4.1.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,7 +19,9 @@ const app = express();
 app.set("views", [
     path.join(__dirname, "views"),
     path.join(__dirname, "/../node_modules/govuk-frontend/dist"),
-    path.join(__dirname, "node_modules/govuk-frontend/dist")
+    path.join(__dirname, "node_modules/govuk-frontend/dist"),
+    path.join(__dirname, "/../node_modules/@companieshouse/ch-node-utils/templates"),
+    path.join(__dirname, "node_modules/@companieshouse/ch-node-utils/templates")
 ]);
 
 const nunjucksLoaderOpts = {

--- a/src/middleware/i18next.language.ts
+++ b/src/middleware/i18next.language.ts
@@ -20,6 +20,18 @@ function loadJsonFiles (dir: string): AnyRecord {
 
 export const enableI18next = (app: Application): void => {
 
+    /*
+     * Construct the resources object by merging translations from different sources:
+     * 1. Local translations specific to this application
+     * 2. Navbar translations from the @companieshouse/ch-node-utils package
+     *
+     * We merge these into the 'common' namespace to ensure that navbar translations
+     * are available on all templates, alongside our local common translations.
+     *
+     * This approach allows us to:
+     * - Reuse shared components (like the navbar)
+     * - Maintain the ability to override or extend translations as needed
+     */
     const resources = ["en", "cy"].reduce((acc: AnyRecord, lang) => {
         const chNodeUtilsTranslations: AnyRecord = loadJsonFiles(path.join(chNodeUtilsLocales, lang));
         const localTranslations: AnyRecord = loadJsonFiles(path.join(locales, lang, "translation"));

--- a/src/middleware/i18next.language.ts
+++ b/src/middleware/i18next.language.ts
@@ -1,12 +1,41 @@
 import { Application } from "express";
 import i18next, { InitOptions, Resource } from "i18next";
 import * as middleware from "i18next-http-middleware";
-import requireDir from "require-directory";
 import path from "path";
+import fs from "fs";
+import { AnyRecord } from "../types/util-types";
 
 const locales = path.join(__dirname, "/../locales");
+const chNodeUtilsLocales = path.join(__dirname, "/../../node_modules/@companieshouse/ch-node-utils/locales");
+
+function loadJsonFiles (dir: string): AnyRecord {
+    return fs.readdirSync(dir)
+        .filter(file => file.endsWith(".json"))
+        .reduce((acc: AnyRecord, file) => {
+            const fileName = path.parse(file).name;
+            acc[fileName] = JSON.parse(fs.readFileSync(path.join(dir, file), "utf8"));
+            return acc;
+        }, {});
+}
+
 export const enableI18next = (app: Application): void => {
-    const resources = requireDir(module, locales) as Resource;
+
+    const resources = ["en", "cy"].reduce((acc: AnyRecord, lang) => {
+        const chNodeUtilsTranslations: AnyRecord = loadJsonFiles(path.join(chNodeUtilsLocales, lang));
+        const localTranslations: AnyRecord = loadJsonFiles(path.join(locales, lang, "translation"));
+
+        acc[lang] = {
+            translation: {
+                ...localTranslations,
+                common: {
+                    ...chNodeUtilsTranslations.navbar as AnyRecord,
+                    ...localTranslations.common as AnyRecord
+                }
+            }
+        };
+
+        return acc;
+    }, {}) as Resource;
 
     const options: InitOptions = {
         preload: ["en", "cy"],

--- a/src/views/partials/nav/top.njk
+++ b/src/views/partials/nav/top.njk
@@ -1,45 +1,6 @@
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-        <div class="js-toggle-nav" id="global-nav">
-            <nav role="navigation" class="content" aria-label="{{lang.main_nav_bar}}">
-                {% if userEmailAddress %}
-                    <a href="#navigation" class="js-header-toggle menu">{{ userEmailAddress }}
-                        <span class="govuk-visually-hidden">{{lang.click_to_expand_or_collaps}}</span>
-                    </a>
-                {% else %}
-                    <a id="user-signin-mobile" href="/signin" class="sign-in govuk-link">Sign in / Register</a>
-                {% endif %}
+{% from "navbar.njk" import addPredefinedNavbar %}
 
-                <ul id="navigation">
-                    <li id="signed-in-user" class="user">
-                        {{ userEmailAddress }}:
-                    </li>
-                    <li class="your-companies">
-                        <a class="govuk-link" id="your-companies" href="/your-companies">{{lang.your_companies_header}}</a>
-                    </li>
-                    <li class="your-filings">
-                        <a class="govuk-link" id="your-filings" href="/user/transactions">{{lang.your_filings_header}}</a>
-                    </li>
-                    <li class="companies-you-follow">
-                        <a class="govuk-link" id="companies-you-follow" href="{{ chsMonitorGuiUrl }}">{{lang.companies_you_follow_header}}</a>
-                    </li>
-                    <li class="basket">
-                        <a class="govuk-link" id="basket" href="/basket">{{lang.basket_header}}</a>
-                    </li>
-
-                    <!-- Note: GOV.UK One Login uses Security instead of 'Your details' in Webfiling its "Manage account"-->
-                    <li class="your-details">
-                        <a class="govuk-link" id="your-details" href="/user/account">{{lang.manage_account_header}}</a>
-                    </li>
-
-                    <li class="authenticated">
-                        <a class="govuk-link" id="user-signout" href="/signout">{{lang.sign_out_header}}</a>
-                    </li>
-                </ul>
-            </nav>
-        </div>
-    </div>
-</div>
+{{ addPredefinedNavbar(userEmailAddress, chsMonitorGuiUrl, lang) }}
 
 <nav class="govuk-language-select" role="navigation" aria-label="{{lang.language_switcher}}">
     <ul class="govuk-language-select__list">


### PR DESCRIPTION
- Replace custom navbar with predefined navbar from CH Node Utils
- Update app.ts to include CH Node Utils templates in view paths
- Modify i18next configuration to load translations from CH Node Utils
- Update package.json and package-lock.json with new dependency