### PR TITLE
IDVA6-1556: Add cookie consent banner with i18n support

### DIFF
--- a/locales/cy/common.json
+++ b/locales/cy/common.json
@@ -46,5 +46,18 @@
     "except_where_otherwise_stated_footer": ", heblaw lle nodir yn wahanol",
     "crown_copyright_footer": "© Hawlfraint y Goron",
     "generic_error_message": "Roedd camgymeriad yn prosesu eich cais. Ceisiwch eto, os gwelwch yn dda.",
-    "opens_in_a_new_tab": "[CY] Opens in a new tab"
+    "opens_in_a_new_tab": "[CY] Opens in a new tab",
+    "cookies_on_companies_house_services": "[CY] Cookies on Companies House services",
+    "we_use_essential_cookies": "[CY] We use some essential cookies to make our services work.",
+    "we_use_analytics_cookies": "[CY] We'd also like to use analytics cookies so we can understand how you use our services and to make improvements.",
+    "accepted_analytics_cookies": "[CY] You've accepted analytics cookies.",
+    "rejected_analytics_cookies": "[CY] You've rejected analytics cookies.",
+    "change_cookie_settings": "[CY] change your cookie settings",
+    "at_any_time": "[CY] at any time.",
+    "you_can": "[CY] You can",
+    "accept_analytics_cookies": "[CY] Accept analytics cookies",
+    "reject_analytics_cookies": "[CY] Reject analytics cookies",
+    "view_cookies": "[CY] View cookies",
+    "hide_this_message": "[CY] Hide this message",
+    "noscript_cookie_message": "[CY] We use cookies to make our services work and collect analytics information. To accept or reject analytics cookies, turn on JavaScript in your browser settings and reload this page."
 }

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -46,5 +46,19 @@
     "except_where_otherwise_stated_footer": ", except where otherwise stated",
     "crown_copyright_footer": "© Crown copyright",
     "generic_error_message": "There was an error processing your request. Please try again.",
-    "opens_in_a_new_tab": "Opens in a new tab"
+    "opens_in_a_new_tab": "Opens in a new tab",
+    "cookies_on_companies_house_services": "Cookies on Companies House services",
+    "we_use_essential_cookies": "We use some essential cookies to make our services work.",
+    "we_use_analytics_cookies": "We'd also like to use analytics cookies so we can understand how you use our services and to make improvements.",
+    "accepted_analytics_cookies": "You've accepted analytics cookies.",
+    "rejected_analytics_cookies": "You've rejected analytics cookies.",
+    "change_cookie_settings": "change your cookie settings",
+    "at_any_time": "at any time.",
+    "you_can": "You can",
+    "accept_analytics_cookies": "Accept analytics cookies",
+    "reject_analytics_cookies": "Reject analytics cookies",
+    "view_cookies": "View cookies",
+    "hide_this_message": "Hide this message",
+    "noscript_cookie_message": "We use cookies to make our services work and collect analytics information. To accept or reject analytics cookies, turn on JavaScript in your browser settings and reload this page."
 }
+

--- a/src/views/partials/cookie_consent_banner.njk
+++ b/src/views/partials/cookie_consent_banner.njk
@@ -1,27 +1,27 @@
 {% from "govuk/components/cookie-banner/macro.njk"  import govukCookieBanner %}
 
 {% set html %}
-<p>We use some essential cookies to make our services work.</p>
-<p>We'd also like to use analytics cookies so we can understand how you use our services and to make improvements.</p>
+  <p>{{ lang.we_use_essential_cookies }}</p>
+  <p>{{ lang.we_use_analytics_cookies }}</p>
 {% endset %}
 
 {% set acceptHtml %}
-<p>You've accepted analytics cookies. You can <a class="govuk-link" href="{{ chsUrl }}/help/cookies">change your cookie settings</a> at any time.</p>
+  <p>{{ lang.accepted_analytics_cookies }} {{ lang.you_can }} <a class="govuk-link" href="{{ chsUrl }}/help/cookies">{{ lang.change_cookie_settings }}</a> {{ lang.at_any_time }}</p>
 {% endset %}
 
 {% set rejectHtml %}
-<p>You've rejected analytics cookies. You can <a class="govuk-link" href="{{ chsUrl }}/help/cookies">change your cookie settings</a> at any time.</p>
+  <p>{{ lang.rejected_analytics_cookies }} {{ lang.you_can }} <a class="govuk-link" href="{{ chsUrl }}/help/cookies">{{ lang.change_cookie_settings }}</a> {{ lang.at_any_time }}</p>
 {% endset %}
 
 {{ govukCookieBanner({
-  ariaLabel: "Cookies on Companies House services",
+  ariaLabel: lang.cookies_on_companies_house_services,
   attributes: {
     id: "cookie-banner"
   },
   hidden: true,
   messages: [
     {
-      headingText: "Cookies on Companies House services",
+      headingText: lang.cookies_on_companies_house_services,
       attributes: {
       id: "accept-or-reject-message"
     },
@@ -29,7 +29,7 @@
       html: html,
       actions: [
       {
-        text: "Accept analytics cookies",
+        text: lang.accept_analytics_cookies,
         type: "button",
         name: "cookies",
         value: "accept",
@@ -38,7 +38,7 @@
       }
       },
       {
-        text: "Reject analytics cookies",
+        text: lang.reject_analytics_cookies,
         type: "button",
         name: "cookies",
         value: "reject",
@@ -47,7 +47,7 @@
       }
       },
       {
-        text: "View cookies",
+        text: lang.view_cookies,
         href: chsUrl + "/help/cookies"
       }
     ]
@@ -61,7 +61,7 @@
       hidden: true,
       actions: [
       {
-        text: "Hide this message",
+        text: lang.hide_this_message,
         type: "button",
         name: "hide",
         value: "hide",
@@ -80,7 +80,7 @@
       hidden: true,
       actions: [
       {
-        text: "Hide this message",
+        text: lang.hide_this_message,
         type: "button",
         name: "hide",
         value: "hide",
@@ -94,12 +94,12 @@
 }) }}
 
 <noscript>
-    {{ govukCookieBanner({
-    ariaLabel: "Cookies on Companies House services",
+  {{ govukCookieBanner({
+    ariaLabel: lang.cookies_on_companies_house_services,
     messages: [
       {
-        headingText: "Cookies on Companies House services",
-        text: "We use cookies to make our services work and collect analytics information. To accept or reject analytics cookies, turn on JavaScript in your browser settings and reload this page."
+        headingText: lang.cookies_on_companies_house_services,
+        text: lang.noscript_cookie_message
       }
     ]
   }) }}


### PR DESCRIPTION
- Implement cookie consent banner in cookie_consent_banner.njk
- Add cookie-related translations to English and Welsh locale files
- Update banner text to use localized strings
- Include new keys for analytics cookies acceptance/rejection messages