### PR TITLE
IDVA-1565 update error handling, remove try catches

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -147,6 +147,7 @@ const config: Config = {
 
     // The test environment that will be used for testing
     // testEnvironment: "jest-environment-node",
+    testEnvironment: "node",
 
     // Options that will be passed to the testEnvironment
     // testEnvironmentOptions: {},

--- a/src/routers/controllers/httpErrorController.ts
+++ b/src/routers/controllers/httpErrorController.ts
@@ -24,7 +24,10 @@ export const httpErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
             `A ${err.statusCode} ${err.name} error occurred when a ${req.method} request was made to ${req.originalUrl}. Re-routing to the error template page. Error name: ${err.name}, Error status: ${err.status}, Error message:  + ${err.message}, Stack: " + ${err.stack}`
         );
         const statusCode: number = err.statusCode || 500;
-
+        if (err.redirctToYourCompanies) {
+            logger.error(err.message);
+            return res.redirect(constants.LANDING_URL);
+        }
         res.status(statusCode).render(constants.SERVICE_UNAVAILABLE_TEMPLATE, {
             lang: getTranslationsForView(req.lang, constants.SERVICE_UNAVAILABLE),
             templateName: constants.SERVICE_UNAVAILABLE

--- a/src/routers/controllers/manageAuthorisedPeopleController.ts
+++ b/src/routers/controllers/manageAuthorisedPeopleController.ts
@@ -6,20 +6,17 @@ import { deleteExtraData, getExtraData, setExtraData } from "../../lib/utils/ses
 export const manageAuthorisedPeopleControllerGet = async (req: Request, res: Response): Promise<void> => {
 
     const handler = new ManageAuthorisedPeopleHandler();
-    try {
-        const viewData = await handler.execute(req);
-        const companyNumber: string = getExtraData(req.session, constants.COMPANY_NUMBER);
-        const managedAuthorisedPeopleIndicator = companyNumber;
+    const viewData = await handler.execute(req);
+    const companyNumber: string = getExtraData(req.session, constants.COMPANY_NUMBER);
+    const managedAuthorisedPeopleIndicator = companyNumber;
 
-        deleteExtraData(req.session, constants.CANCEL_URL_EXTRA);
-        deleteExtraData(req.session, constants.REMOVE_URL_EXTRA);
+    deleteExtraData(req.session, constants.CANCEL_URL_EXTRA);
+    deleteExtraData(req.session, constants.REMOVE_URL_EXTRA);
 
-        setExtraData(req.session, constants.MANAGE_AUTHORISED_PEOPLE_INDICATOR, managedAuthorisedPeopleIndicator);
+    setExtraData(req.session, constants.MANAGE_AUTHORISED_PEOPLE_INDICATOR, managedAuthorisedPeopleIndicator);
 
-        res.render(constants.MANAGE_AUTHORISED_PEOPLE_PAGE, {
-            ...viewData
-        });
-    } catch (error) {
-        return res.redirect(constants.LANDING_URL);
-    }
+    res.render(constants.MANAGE_AUTHORISED_PEOPLE_PAGE, {
+        ...viewData
+    });
+
 };

--- a/src/routers/handlers/yourCompanies/manageAuthorisedPeopleHandler.ts
+++ b/src/routers/handlers/yourCompanies/manageAuthorisedPeopleHandler.ts
@@ -39,13 +39,9 @@ export class ManageAuthorisedPeopleHandler extends GenericHandler {
             companyAssociations = await getCompanyAssociations(req, companyNumber, undefined, undefined, pageNumber - 1);
         }
 
-        try {
-            if (cancellation && req.originalUrl.includes(constants.CONFIRMATION_CANCEL_PERSON_URL)) {
-                deleteExtraData(req.session, constants.REMOVE_PERSON);
-                await this.handleCancellation(req, cancellation, companyNumber);
-            }
-        } catch (error) {
-            logger.error(`Error on cancellation: ${JSON.stringify(error)}`);
+        if (cancellation && req.originalUrl.includes(constants.CONFIRMATION_CANCEL_PERSON_URL)) {
+            deleteExtraData(req.session, constants.REMOVE_PERSON);
+            await this.handleCancellation(req, cancellation, companyNumber);
         }
 
         this.handleRemoveConfirmation(req);
@@ -84,8 +80,10 @@ export class ManageAuthorisedPeopleHandler extends GenericHandler {
     private async preventUnauthorisedAccess (req: Request, companyNumber: string) {
         const isAssociated: AssociationStateResponse = await isOrWasCompanyAssociatedWithUser(req, companyNumber);
         if (isAssociated.state !== AssociationState.COMPANY_ASSOCIATED_WITH_USER) {
-            return Promise.reject(createError(StatusCodes.FORBIDDEN));
+            const errorText = `${ManageAuthorisedPeopleHandler.name} ${this.preventUnauthorisedAccess.name}: Unauthorised, redirecting to your companies`;
+            return Promise.reject(createError(StatusCodes.FORBIDDEN, errorText, { redirctToYourCompanies: true }));
         }
+        return Promise.resolve();
     }
 
     private getViewData (companyNumber: string, lang: AnyRecord): ViewData {

--- a/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
+++ b/test/src/routers/controllers/manageAuthorisedPeopleController.test.ts
@@ -54,10 +54,10 @@ describe("GET /your-companies/manage-authorised-people/:companyNumber", () => {
         expect(response.status).toEqual(200);
     });
 
-    it("should redirect to the langing page if user not authorised to see the page", async () => {
+    it("should redirect to the landing page /your-companies if user not authorised to see the page", async () => {
         // Given
-        const isAssociated: AssociationStateResponse = { state: AssociationState.COMPANY_AWAITING_ASSOCIATION_WITH_USER, associationId: "" };
-        isOrWasCompanyAssociatedWithUserSpy.mockReturnValue(isAssociated);
+        const notAssociated: AssociationStateResponse = { state: AssociationState.COMPANY_AWAITING_ASSOCIATION_WITH_USER, associationId: "" };
+        isOrWasCompanyAssociatedWithUserSpy.mockReturnValue(notAssociated);
         // When
         const response = await router.get(url);
         // Then


### PR DESCRIPTION
**Link to Jira** 
https://companieshouse.atlassian.net/browse/IDVA6-1565

**Change Description**
This PR removes the try...catch in the manageAuthorisedPeopleControllerGet and manageAuthorisedPeopleHandler This lets the error move along the chain allowing the middleware error handler catch the errors instead.

Old Behaviour 
When accessing a page handled by manageAuthorisedPeopleControllerGet, and any error happens such as API request fails => user is redirected to your-companies.
New behaviour 
When accessing a page handled by manageAuthorisedPeopleControllerGet And the user is unauthorised => log error and redirect to your companies Any other type of error occurs => log the error and render an error page