### PR TITLE
IDVA6-2079 Fixing Unit Test Memory Leaks Warnings

### DIFF
--- a/test/src/routers/controllers/checkPresenterController.test.ts
+++ b/test/src/routers/controllers/checkPresenterController.test.ts
@@ -10,6 +10,8 @@ import * as en from "../../../../locales/en/add-presenter-check-details.json";
 import * as cy from "../../../../locales/cy/add-presenter-check-details.json";
 import { getFullUrl } from "../../../../src/lib/utils/urlUtils";
 
+jest.mock("../../../../src/lib/Logger");
+
 jest.mock("../../../../src/services/companyProfileService");
 const session: Session = new Session();
 

--- a/test/src/routers/controllers/companyInvitationsAcceptController.test.ts
+++ b/test/src/routers/controllers/companyInvitationsAcceptController.test.ts
@@ -11,6 +11,7 @@ import * as constants from "../../../../src/constants";
 import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
 import { getFullUrl } from "../../../../src/lib/utils/urlUtils";
 
+jest.mock("../../../../src/lib/Logger");
 jest.mock("../../../../src/services/associationsService");
 
 const router = supertest(app);

--- a/test/src/routers/controllers/companyInvitationsDeclineController.test.ts
+++ b/test/src/routers/controllers/companyInvitationsDeclineController.test.ts
@@ -9,6 +9,7 @@ import * as constants from "../../../../src/constants";
 import * as sessionUtils from "../../../../src/lib/utils/sessionUtils";
 import { getFullUrl } from "../../../../src/lib/utils/urlUtils";
 
+jest.mock("../../../../src/lib/Logger");
 jest.mock("../../../../src/services/associationsService");
 
 const router = supertest(app);

--- a/test/src/routers/controllers/yourCompaniesController.paginationContent.test.ts
+++ b/test/src/routers/controllers/yourCompaniesController.paginationContent.test.ts
@@ -10,6 +10,8 @@ import * as cyCommon from "../../../../locales/cy/common.json";
 import * as enCommon from "../../../../locales/en/common.json";
 jest.mock("../../../../src/services/associationsService");
 
+jest.mock("../../../../src/lib/Logger");
+
 const router = supertest(app);
 
 const mockGetUserAssociations = getUserAssociations as jest.Mock;


### PR DESCRIPTION
Fixing unit test memory leaks warnings by mocking the Logger using Jest.
This warnings was appearing in the console/terminals and this PR fixes it and it no longer shows the warnings of the terminal/console.

`(node:34503) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 uncaughtException listeners added to [process]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit (Use node --trace-warnings ... to show where the warning was created)`