### PR TITLE
IDVA6-2345 Adding Redirect If Invalid Email Address For Resend Email

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,7 @@ export const CONFIRM_COMPANY_DETAILS_INDICATOR = "confirmCompanyDetailsIndicator
 export const CANCEL_URL_EXTRA = "cancelPersonUrlExtraData";
 export const REMOVE_URL_EXTRA = "removePersonUrlExtraData";
 export const REMOVE_COMPANY_URL_EXTRA = "removeCompanyUrlExtraData";
+export const CSRF_ERRORS = "csrfErrors";
 
 // Paths to Nunjucks template files
 export const SERVICE_UNAVAILABLE_TEMPLATE = "partials/service_unavailable";

--- a/src/routers/controllers/errorController.ts
+++ b/src/routers/controllers/errorController.ts
@@ -44,8 +44,7 @@ export const csrfErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
         logger.error(
             `CSRF Error occured ${err.message}, Stack: ${err.stack}`
         );
-
-        res.status(403).redirect(getFullUrl(constants.SOMETHING_WENT_WRONG_URL));
+        res.status(403).redirect(`${getFullUrl(constants.SOMETHING_WENT_WRONG_URL)}?${constants.CSRF_ERRORS}`);
     } else {
         next(err);
     }

--- a/src/routers/controllers/resendEmailController.ts
+++ b/src/routers/controllers/resendEmailController.ts
@@ -15,6 +15,7 @@ export const resendEmailController = async (req: Request, res: Response): Promis
         logger.info(
             `Email ${email} invalid or not on the authorisation list for company ${companyNumber}`
         );
+        return res.status(400).redirect(getFullUrl(constants.SOMETHING_WENT_WRONG_URL));
     } else {
         const emailSendResponse: string = await createAssociation(req, companyNumber, email);
         if (emailSendResponse) {
@@ -28,5 +29,5 @@ export const resendEmailController = async (req: Request, res: Response): Promis
             );
         }
     }
-    return res.status(400).render(constants.SERVICE_UNAVAILABLE_TEMPLATE);
+    return res.status(400).redirect(getFullUrl(constants.SOMETHING_WENT_WRONG_URL));
 };

--- a/src/routers/controllers/resendEmailController.ts
+++ b/src/routers/controllers/resendEmailController.ts
@@ -29,5 +29,4 @@ export const resendEmailController = async (req: Request, res: Response): Promis
             );
         }
     }
-    return res.status(400).redirect(getFullUrl(constants.SOMETHING_WENT_WRONG_URL));
 };

--- a/src/routers/controllers/somethingWentWrongController.ts
+++ b/src/routers/controllers/somethingWentWrongController.ts
@@ -5,5 +5,7 @@ import { SomethingWentWrongHandler } from "../handlers/yourCompanies/somethingWe
 export const somethingWentWrongControllerGet = async (req: Request, res: Response): Promise<void> => {
     const handler = new SomethingWentWrongHandler();
     const viewData = await handler.execute(req);
-    res.status(403).render(constants.SERVICE_UNAVAILABLE_TEMPLATE, viewData);
+    const statusCode = viewData.csrfErrors ? 403 : 500;
+
+    res.status(statusCode).render(constants.SERVICE_UNAVAILABLE_TEMPLATE, viewData);
 };

--- a/src/routers/handlers/yourCompanies/somethingWentWrongHandler.ts
+++ b/src/routers/handlers/yourCompanies/somethingWentWrongHandler.ts
@@ -33,6 +33,6 @@ export class SomethingWentWrongHandler extends GenericHandler {
     }
 
     private isCsrfError (req: Request): boolean {
-        return Object.prototype.hasOwnProperty.call(req.query, constants.CSRF_ERRORS);
+        return Object.hasOwn(req.query, constants.CSRF_ERRORS);
     }
 }

--- a/src/routers/handlers/yourCompanies/somethingWentWrongHandler.ts
+++ b/src/routers/handlers/yourCompanies/somethingWentWrongHandler.ts
@@ -17,16 +17,22 @@ export class SomethingWentWrongHandler extends GenericHandler {
         this.viewData = {
             templateName: constants.SERVICE_UNAVAILABLE,
             lang: {},
-            csrfErrors: true,
+            csrfErrors: false,
             title: ""
         };
     }
 
     async execute (req: Request): Promise<SomethingWentWrongViewData> {
         const translations = getTranslationsForView(req.lang || "en", constants.SERVICE_UNAVAILABLE);
+        const csrfError = this.isCsrfError(req);
         this.viewData.lang = translations;
+        this.viewData.csrfErrors = csrfError;
         this.viewData.title = `${translations.sorry_something_went_wrong}${translations.title_end}`;
 
         return Promise.resolve(this.viewData);
+    }
+
+    private isCsrfError (req: Request): boolean {
+        return Object.prototype.hasOwnProperty.call(req.query, constants.CSRF_ERRORS);
     }
 }

--- a/test/integration/your-companies/manage-authorised-people-email-resent/userEmail/get.test.ts
+++ b/test/integration/your-companies/manage-authorised-people-email-resent/userEmail/get.test.ts
@@ -38,9 +38,14 @@ describe("GET /your-companies/manage-authorised-people-email-resent/:userEmail",
     it("should reject invalid emails", async () => {
         // Given
         const url = "/your-companies/manage-authorised-people-email-resent/bob1bob.com";
+        const expectedRedirectUrl = "/your-companies/something-went-wrong";
+
         // When
         const response = await router.get(url);
+
         // Then
-        expect(response.statusCode).toEqual(400);
+        expect(response.statusCode).toEqual(302);
+        expect(response.header.location).toEqual(expectedRedirectUrl);
     });
+
 });

--- a/test/integration/your-companies/something-went-wrong/get.test.ts
+++ b/test/integration/your-companies/something-went-wrong/get.test.ts
@@ -1,6 +1,7 @@
 import mocks from "../../../mocks/all.middleware.mock";
 import app from "../../../../src/app";
 import supertest from "supertest";
+import * as constants from "../../../../src/constants";
 import en from "../../../../locales/en/service-unavailable.json";
 import cy from "../../../../locales/cy/service-unavailable.json";
 
@@ -24,24 +25,44 @@ describe("GET /your-companies/something-went-wrong", () => {
     });
 
     test.each([
-        [403, "English", "default", en],
-        [403, "English", "en", en],
-        [403, "Welsh", "cy", cy]
+        { status: 403, langInfo: "English", langVersion: "en", condition: "CSRF error", lang: en, csrfError: true },
+        { status: 403, langInfo: "English", langVersion: undefined, condition: "CSRF error", lang: en, csrfError: true },
+        { status: 403, langInfo: "English", langVersion: "en", condition: "CSRF error", lang: en, csrfError: true },
+        { status: 500, langInfo: "English", langVersion: "en", condition: "it is not a CSRF error", lang: en, csrfError: false },
+        { status: 500, langInfo: "English", langVersion: undefined, condition: "it is not a CSRF error", lang: en, csrfError: false },
+        { status: 500, langInfo: "English", langVersion: "en", condition: "it is not a CSRF error", lang: en, csrfError: false }
     ])("should return status %s and %s content if language set to %s",
-        async (status, _langVersionInfo, langVersion, lang) => {
+        async ({ status, langVersion, lang, csrfError }) => {
+
             // Given
-            const langParam = langVersion === "default" ? "" : `?lang=${langVersion}`;
+            const csrfErrorString = csrfError ? `${constants.CSRF_ERRORS}` : "";
+            const langString = langVersion ? `lang=${langVersion}` : "";
+            let queryString = "";
+            if (langVersion && csrfError) {
+                queryString = `?${langString}&${csrfErrorString}`;
+            } else if (langVersion || csrfError) {
+                queryString = langVersion ? `?${langString}` : `?${csrfErrorString}`;
+            }
             // When
-            const result = await router.get(`${url}${langParam}`);
+            const result = await router.get(`${url}${queryString}`);
             // Then
+            expect(mocks.mockSessionMiddleware).toHaveBeenCalled();
+            expect(mocks.mockAuthenticationMiddleware).toHaveBeenCalled();
             expect(result.status).toEqual(status);
-            expect(result.text).toContain(lang.sorry_something_went_wrong);
-            expect(result.text).toContain(lang.we_have_not_been_able_to_save);
-            expect(result.text).toContain(lang.try_the_following);
-            expect(result.text).toContain(lang.use_the_back_link);
-            expect(result.text).toContain(lang.sign_out_of_the_service);
-            expect(result.text).toContain(lang.if_the_problem_continues);
-            expect(result.text).toContain(lang.contact_us_link);
-            expect(result.text).toContain(lang.for_help);
+            if (status === 403) {
+                expect(result.text).toContain(lang.sorry_something_went_wrong);
+                expect(result.text).toContain(lang.we_have_not_been_able_to_save);
+                expect(result.text).toContain(lang.try_the_following);
+                expect(result.text).toContain(lang.use_the_back_link);
+                expect(result.text).toContain(lang.sign_out_of_the_service);
+                expect(result.text).toContain(lang.if_the_problem_continues);
+                expect(result.text).toContain(lang.contact_us_link);
+                expect(result.text).toContain(lang.for_help);
+            } else {
+                expect(result.text).toContain(lang.page_header);
+                expect(result.text).toContain(lang.try_again_later);
+                expect(result.text).toContain(lang.contact_companies_house);
+                expect(result.text).toContain(lang.if_you_have_questions);
+            }
         });
 });

--- a/test/unit/src/routers/controllers/errorController.test.ts
+++ b/test/unit/src/routers/controllers/errorController.test.ts
@@ -46,7 +46,10 @@ describe("csrfErrorHandler", () => {
         csrfErrorHandler(err, request, response, mockNext);
         // Then
         expect(response.status).toHaveBeenCalledWith(403);
-        expect(response.redirect).toHaveBeenCalledWith(getFullUrl(constants.SOMETHING_WENT_WRONG_URL));
+        expect(response.redirect).toHaveBeenCalledWith(
+            `${getFullUrl(constants.SOMETHING_WENT_WRONG_URL)}?${constants.CSRF_ERRORS}`
+        );
+
         expect(logger.error).toHaveBeenCalledTimes(1);
         expect(logger.error).toHaveBeenCalledWith(
             expect.stringContaining("CSRF Error occured")

--- a/test/unit/src/routers/controllers/resendEmailController.test.ts
+++ b/test/unit/src/routers/controllers/resendEmailController.test.ts
@@ -40,17 +40,15 @@ describe("resendEmailController", () => {
             req.params = { [constants.USER_EMAIL]: email };
             const expectedMessage = `Email ${email} invalid or not on the authorisation list for company ${companyNumber}`;
             validateEmailStringSpy.mockReturnValue(false);
+            const expectedUrl = "your-companies/something-went-wrong";
+            getFullUrlSpy.mockReturnValue(expectedUrl);
             // When
             await resendEmailController(req as Request, res as Response);
             // Then
-            expect(getExtraDataSpy).toHaveBeenCalledTimes(1);
-            expect(getExtraDataSpy).toHaveBeenCalledWith(expect.anything(), constants.COMPANY_NUMBER);
-            expect(validateEmailStringSpy).toHaveBeenCalledTimes(1);
             expect(validateEmailStringSpy).toHaveBeenCalledWith(email);
-            expect(logger.info).toHaveBeenCalledTimes(1);
             expect(logger.info).toHaveBeenCalledWith(expectedMessage);
-            expect(renderMock).toHaveBeenCalledTimes(1);
-            expect(renderMock).toHaveBeenCalledWith(constants.SERVICE_UNAVAILABLE_TEMPLATE);
+            expect(res.status).toHaveBeenCalledWith(400);
+            expect(res.redirect).toHaveBeenCalledWith(expectedUrl);
         });
 
     it("should redirect to manage authorised people confirmation email resent page",

--- a/test/unit/src/routers/controllers/resendEmailController.test.ts
+++ b/test/unit/src/routers/controllers/resendEmailController.test.ts
@@ -31,7 +31,7 @@ describe("resendEmailController", () => {
         jest.clearAllMocks();
     });
 
-    it("should render service unavailable page if provided email is invalid",
+    it("should redirect to something went wrong page if provided email is invalid",
         async () => {
             // Given
             const companyNumber = "12345";

--- a/test/unit/src/routers/controllers/somethingWentWrongController.test.ts
+++ b/test/unit/src/routers/controllers/somethingWentWrongController.test.ts
@@ -34,8 +34,12 @@ describe("somethingWentWrongControllerGet", () => {
     it("should render service unavailable page", async () => {
         // Given
         const expectedViewData = {
-            key: "value"
+            csrfErrors: true,
+            lang: {},
+            title: "",
+            templateName: constants.SERVICE_UNAVAILABLE_TEMPLATE
         };
+
         mockExecute.mockReturnValue(expectedViewData);
         // When
         await somethingWentWrongControllerGet(req as Request, res as Response);
@@ -46,4 +50,20 @@ describe("somethingWentWrongControllerGet", () => {
         expect(renderMock).toHaveBeenCalledTimes(1);
         expect(renderMock).toHaveBeenCalledWith(constants.SERVICE_UNAVAILABLE_TEMPLATE, expectedViewData);
     });
+
+    it("should render with status 500 if not a CSRF error", async () => {
+        const expectedViewData = {
+            csrfErrors: false,
+            lang: {},
+            title: "",
+            templateName: constants.SERVICE_UNAVAILABLE_TEMPLATE
+        };
+
+        mockExecute.mockReturnValue(expectedViewData);
+        await somethingWentWrongControllerGet(req as Request, res as Response);
+
+        expect(statusMock).toHaveBeenCalledWith(500);
+        expect(renderMock).toHaveBeenCalledWith(constants.SERVICE_UNAVAILABLE_TEMPLATE, expectedViewData);
+    });
+
 });

--- a/test/unit/src/routers/handlers/yourCompanies/somethingWentWrongHandler.test.ts
+++ b/test/unit/src/routers/handlers/yourCompanies/somethingWentWrongHandler.test.ts
@@ -16,13 +16,13 @@ describe("SomethingWentWrongHandler", () => {
         somethingWentWrongHandler = new SomethingWentWrongHandler();
     });
 
-    it("should return view data", async () => {
+    it("should return view data if the lang is provided in the request", async () => {
         // Given
         const lang = "en";
         const req: Request = mockParametrisedRequest({
             session: new Session(),
             lang,
-            query: { [constants.CSRF_ERRORS]: "" } // simulate ?csrfErrors
+            query: { [constants.CSRF_ERRORS]: "" }
         });
 
         const translations = {
@@ -41,6 +41,32 @@ describe("SomethingWentWrongHandler", () => {
         // Then
         expect(getTranslationsForViewSpy).toHaveBeenCalledTimes(1);
         expect(getTranslationsForViewSpy).toHaveBeenCalledWith(lang, constants.SERVICE_UNAVAILABLE);
+        expect(response).toEqual(viewData);
+    });
+
+    it("should return view data if no lang is provided in request", async () => {
+        // Given
+        const req: Request = mockParametrisedRequest({
+            session: new Session(),
+            query: { [constants.CSRF_ERRORS]: "" }
+        });
+
+        const translations = {
+            sorry_something_went_wrong: "Sorry something went wrong",
+            title_end: " - title end"
+        };
+        getTranslationsForViewSpy.mockReturnValueOnce(translations);
+        const viewData = {
+            templateName: constants.SERVICE_UNAVAILABLE,
+            lang: translations,
+            csrfErrors: true,
+            title: "Sorry something went wrong - title end"
+        };
+        // When
+        const response = await somethingWentWrongHandler.execute(req);
+        // Then
+        expect(getTranslationsForViewSpy).toHaveBeenCalledTimes(1);
+        expect(getTranslationsForViewSpy).toHaveBeenCalledWith("en", constants.SERVICE_UNAVAILABLE);
         expect(response).toEqual(viewData);
     });
 });

--- a/test/unit/src/routers/handlers/yourCompanies/somethingWentWrongHandler.test.ts
+++ b/test/unit/src/routers/handlers/yourCompanies/somethingWentWrongHandler.test.ts
@@ -19,7 +19,12 @@ describe("SomethingWentWrongHandler", () => {
     it("should return view data", async () => {
         // Given
         const lang = "en";
-        const req: Request = mockParametrisedRequest({ session: new Session(), lang });
+        const req: Request = mockParametrisedRequest({
+            session: new Session(),
+            lang,
+            query: { [constants.CSRF_ERRORS]: "" } // simulate ?csrfErrors
+        });
+
         const translations = {
             sorry_something_went_wrong: "Sorry something went wrong",
             title_end: " - title end"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2019",
+    "target": "ES2022",
     "module": "commonjs",
     "esModuleInterop": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
### JIRA link
https://companieshouse.atlassian.net/browse/IDVA6-2345


### Change description
- Updating resendEmailController to redirect to something went wrong page if email is invalid
- Updating somethingWentWrongController to include status code and render service unavailable template.
- Updating somethingWentWrongHandler to include a check for csrfError in a dynamic way.
- Updating unit tests and integration tests needed.

![Screenshot 2025-04-03 at 13 24 39](https://github.com/user-attachments/assets/93ad8a68-e505-46dc-aa5f-2c1506d5b28f)
![Screenshot 2025-04-03 at 13 15 34](https://github.com/user-attachments/assets/e8af6c3d-6531-448d-ab0a-8dc8ca4365bb)




### Work checklist

- [x] Tests added where applicable
- [x] UI changes meet accessibility criteria
