### PR TITLE
SIV 279 Force company auth code middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@companieshouse/ch-node-utils": "^1.3.23",
                 "@companieshouse/node-session-handler": "^5.2.0",
                 "@companieshouse/structured-logging-node": "^2.0.1",
-                "@companieshouse/web-security-node": "^4.4.3",
+                "@companieshouse/web-security-node": "^4.4.9",
                 "axios": "^1.6.8",
                 "cookie-parser": "^1.4.7",
                 "dotenv": "^16.4.5",
@@ -1096,13 +1096,13 @@
             }
         },
         "node_modules/@companieshouse/web-security-node": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-4.4.3.tgz",
-            "integrity": "sha512-JatTZEVKTrrRwJKyhg4x+0pUTkW5/P4iiIfk0wWnkDnLVeI/XZc92kmFwQ24xvSJMh/FY4NGHNBSMf9RYcFmIw==",
-            "license": "MIT",
+            "version": "4.4.9",
+            "resolved": "https://registry.npmjs.org/@companieshouse/web-security-node/-/web-security-node-4.4.9.tgz",
+            "integrity": "sha512-Jna+hTcVYQf5dK0/fNCFykSF9m83Q2ymwuuoLRY3flIBwMMcMjmxXSZEBBnWxEUShfKnJ/FvkuPjCpIrMUztkA==",
             "dependencies": {
                 "@companieshouse/node-session-handler": "~5.2.0",
                 "@companieshouse/structured-logging-node": "~2.0.1",
+                "crypto": "^1.0.1",
                 "express-async-handler": "^1.2.0",
                 "uuid": "^9.0.1"
             }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@companieshouse/ch-node-utils": "^1.3.23",
         "@companieshouse/node-session-handler": "^5.2.0",
         "@companieshouse/structured-logging-node": "^2.0.1",
-        "@companieshouse/web-security-node": "^4.4.3",
+        "@companieshouse/web-security-node": "^4.4.9",
         "axios": "^1.6.8",
         "cookie-parser": "^1.4.7",
         "dotenv": "^16.4.5",

--- a/src/middleware/company.authentication.ts
+++ b/src/middleware/company.authentication.ts
@@ -1,32 +1,37 @@
 import { NextFunction, Request, Response } from "express";
-import { authMiddleware, AuthOptions } from "@companieshouse/web-security-node";
 import * as constants from "../constants";
 import logger, { createLogMessage } from "../lib/Logger";
+import { authMiddleware, AuthOptions } from "@companieshouse/web-security-node";
 
 /**
  * Middleware to authenticate a user for a specific company based on the company number
  * provided in the request parameters.
  *
- * @param req - The Express request object
- * @param res - The Express response object
- * @param next - The next middleware function in the stack
- * @returns A call to the authentication middleware
+ * @param req - forceAuthCode - boolean indicating whether to force the use of an authentication code
+ * @returns Company authentication middleware function
  */
-export const companyAuthenticationMiddleware = (req: Request, res: Response, next: NextFunction): unknown => {
-    const companyNumber: string | undefined = req.params[constants.COMPANY_NUMBER];
+export const createCompanyAuthenticationMiddleware = (forceAuthCode: boolean) => {
+    return (req: Request, res: Response, next: NextFunction): unknown => {
+        const companyNumber: string | undefined = req.params[constants.COMPANY_NUMBER];
 
-    logger.debug(createLogMessage(req.session, companyAuthenticationMiddleware.name,
-        `starting web security node check: 
-    returnUrl: ${req.originalUrl},
-    chsWebUrl: ${constants.CHS_URL},
-    companyNumber: ${companyNumber}
-    `));
+        logger.debug(createLogMessage(req.session, "companyAuthenticationMiddleware",
+            `starting web security node check: 
+        returnUrl: ${req.originalUrl},
+        chsWebUrl: ${constants.CHS_URL},
+        companyNumber: ${companyNumber},
+        forceAuthCode: ${forceAuthCode} 
+        `));
 
-    const authMiddlewareConfig: AuthOptions = {
-        chsWebUrl: constants.CHS_URL,
-        returnUrl: req.originalUrl,
-        companyNumber: companyNumber
+        const authMiddlewareConfig: AuthOptions = {
+            chsWebUrl: constants.CHS_URL,
+            returnUrl: req.originalUrl,
+            companyNumber: companyNumber,
+            forceAuthCode
+        };
+
+        return authMiddleware(authMiddlewareConfig)(req, res, next);
     };
-
-    return authMiddleware(authMiddlewareConfig)(req, res, next);
 };
+
+export const forceCompanyAuthenticationMiddleware = createCompanyAuthenticationMiddleware(true);
+export const companyAuthenticationMiddleware = createCompanyAuthenticationMiddleware(false);

--- a/src/middleware/companyAuthentication/remove.person.company.authentication.ts
+++ b/src/middleware/companyAuthentication/remove.person.company.authentication.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import * as constants from "../../constants";
 import logger, { createLogMessage } from "../../lib/Logger";
 import { isRemovingThemselves } from "../../lib/utils/removeThemselves";
-import { companyAuthenticationMiddleware } from "../company.authentication";
+import { forceCompanyAuthenticationMiddleware } from "../company.authentication";
 import { Session } from "@companieshouse/node-session-handler";
 
 /**
@@ -27,5 +27,5 @@ export const removeAuthorisedPersonCompanyAuth = (req: Request, res: Response, n
     }
 
     logger.debug(createLogMessage(req.session, removeAuthorisedPersonCompanyAuth.name, `Redirecting to company authentication, removing a user from company ${companyNumber}.`));
-    return companyAuthenticationMiddleware(req, res, next);
+    return forceCompanyAuthenticationMiddleware(req, res, next);
 };

--- a/src/routers/router.ts
+++ b/src/routers/router.ts
@@ -30,7 +30,7 @@ import { removedThemselvesConfirmationControllerGet } from "./controllers/remove
 import { presenterAlreadyAddedNavigation } from "../middleware/navigation/presenterAlreadyAdded.middleware";
 import { removedThemselvesNavigation } from "../middleware/navigation/personRemovedThemselves.middleware";
 import { removeAuthorisedPersonCompanyAuth } from "../middleware/companyAuthentication/remove.person.company.authentication";
-import { companyAuthenticationMiddleware } from "../middleware/company.authentication";
+import { companyAuthenticationMiddleware, forceCompanyAuthenticationMiddleware } from "../middleware/company.authentication";
 import { removeCompanyConfirmedControllerGet } from "./controllers/removeCompanyConfirmedController";
 import { removeCompanyControllerGet, removeCompanyControllerPost } from "./controllers/removeCompanyController";
 import { somethingWentWrongControllerGet } from "./controllers/somethingWentWrongController";
@@ -76,7 +76,7 @@ router.get(constants.REMOVE_COMPANY_CONFIRMED_URL, confirmationCompanyRemovedNav
 
 // Cancel Person
 router.route(constants.COMPANY_AUTH_PROTECTED_CANCEL_PERSON_URL)
-    .get(companyAuthenticationMiddleware, cancelPersonNavigation, cancelPersonControllerGet as RequestHandler)
+    .get(forceCompanyAuthenticationMiddleware, cancelPersonNavigation, cancelPersonControllerGet as RequestHandler)
     .post(companyAuthenticationMiddleware, cancelPersonControllerPost as RequestHandler);
 
 // Confirm Company

--- a/test/mocks/all.middleware.mock.ts
+++ b/test/mocks/all.middleware.mock.ts
@@ -1,6 +1,6 @@
 import mockAuthenticationMiddleware from "./authentication.middleware.mock";
 import { mockSessionMiddleware, mockEnsureSessionCookiePresentMiddleware } from "./session.middleware.mock";
-import mockCompanyAuthenticationMiddleware from "./company.authentication.middleware.mock";
+import { mockCompanyAuthenticationMiddleware, mockForceCompanyAuthenticationMiddleware } from "./company.authentication.middleware.mock";
 import mockCsrfProtectionMiddleware from "./csrf.protection.middleware.mock";
 
 export default {
@@ -8,5 +8,6 @@ export default {
     mockCompanyAuthenticationMiddleware,
     mockSessionMiddleware,
     mockEnsureSessionCookiePresentMiddleware,
-    mockCsrfProtectionMiddleware
+    mockCsrfProtectionMiddleware,
+    mockForceCompanyAuthenticationMiddleware
 };

--- a/test/mocks/company.authentication.middleware.mock.ts
+++ b/test/mocks/company.authentication.middleware.mock.ts
@@ -1,12 +1,17 @@
 import { NextFunction, Request, Response } from "express";
-import { companyAuthenticationMiddleware } from "../../src/middleware/company.authentication";
+import { companyAuthenticationMiddleware, forceCompanyAuthenticationMiddleware } from "../../src/middleware/company.authentication";
 
 jest.mock("../../src/middleware/company.authentication");
 
 // get handle on mocked function
 const mockCompanyAuthenticationMiddleware = companyAuthenticationMiddleware as jest.Mock;
+const mockForceCompanyAuthenticationMiddleware = forceCompanyAuthenticationMiddleware as jest.Mock;
 
 // tell the mock what to return
 mockCompanyAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
+mockForceCompanyAuthenticationMiddleware.mockImplementation((req: Request, res: Response, next: NextFunction) => next());
 
-export default mockCompanyAuthenticationMiddleware;
+export {
+    mockCompanyAuthenticationMiddleware,
+    mockForceCompanyAuthenticationMiddleware
+};


### PR DESCRIPTION
**Link to Jira**
https://companieshouse.atlassian.net/browse/SIV-279

**Description**
In some situations, we want to force a user to add the authenticate for a company even if they have previously authenticated and have the company number stored in their session. We have added forceCompanyAuthenticationMiddleware for this scenario which sets forceAuthCode to true.

Remove yourself - no company auth check
Remove another authorised user - force company auth code each time
Cancel another authorised user - force company auth code each time
Create company association - standard company auth code check, if stored in session it will be skipped