### PR TITLE
SIV-645 Allow http and https subdomain form submissions

### DIFF
--- a/src/middleware/content.security.policy.middleware.config.ts
+++ b/src/middleware/content.security.policy.middleware.config.ts
@@ -24,7 +24,11 @@ export const prepareCSPConfig = (nonce: string): HelmetOptions => {
                 imgSrc: [CDN],
                 styleSrc: [NONCE, CDN],
                 connectSrc: [SELF, PIWIK_URL],
-                formAction: [SELF, PIWIK_CHS_DOMAIN],
+                formAction: [
+                    SELF,
+                    `https://${PIWIK_CHS_DOMAIN}`,
+                    `http://${PIWIK_CHS_DOMAIN}`
+                ],
                 scriptSrc: [SELF, NONCE, CDN, PIWIK_URL],
                 objectSrc: [`'none'`]
             }


### PR DESCRIPTION
**Link to Jira**
https://companieshouse.atlassian.net/browse/SIV-645

**Description**
Modifies the Content Security Policy to allow both HTTP and HTTPS form submissions and redirects, in order to confirm this is the cause of the bug.