### PR TITLE
SIV-707 Content Security Policy update -  allow both http https form submissions

### DIFF
--- a/src/middleware/content.security.policy.middleware.config.ts
+++ b/src/middleware/content.security.policy.middleware.config.ts
@@ -11,7 +11,7 @@ export const prepareCSPConfig = (nonce: string): HelmetOptions => {
     const PIWIK_URL = process.env.PIWIK_URL as string;
     const PIWIK_CHS_DOMAIN = process.env.PIWIK_CHS_DOMAIN as string;
     const CHS_URL = process.env.CHS_URL as string;
-    const HTTP_CHS_URL: string = CHS_URL.replace(/^https:\/\//, "http://") as string;
+    const HTTP_CHS_URL: string = CHS_URL.replace(/^https:\/\//, "http://");
     const SELF = `'self'`;
     const NONCE = `'nonce-${nonce}'`;
     const ONE_YEAR_SECONDS = 31536000;


### PR DESCRIPTION
**Jira**
https://companieshouse.atlassian.net/browse/SIV-707

**Description**
After forms are submitted, the auth service sometimes redirects to HTTP urls, which is blocked by our CSP.
This PR updates the CSP to allow forms to submit and redirect to  http://CHS_URL 