### PR TITLE
SIV-758 clear search related session data on add journey

### DIFF
--- a/src/routers/handlers/yourCompanies/addPresenterHandler.ts
+++ b/src/routers/handlers/yourCompanies/addPresenterHandler.ts
@@ -4,8 +4,9 @@ import { CompanyNameAndNumber, ViewDataWithBackLink } from "../../../types/utilT
 import { getTranslationsForView } from "../../../lib/utils/translations";
 import * as constants from "../../../constants";
 import { validateClearForm, validateEmailString } from "../../../lib/validation/generic";
-import { getExtraData, setExtraData, deleteExtraData } from "../../../lib/utils/sessionUtils";
+import { getExtraData, setExtraData, deleteExtraData, deleteSearchStringEmail } from "../../../lib/utils/sessionUtils";
 import { getManageAuthorisedPeopleFullUrl } from "../../../lib/utils/urlUtils";
+import { Session } from "@companieshouse/node-session-handler";
 
 interface AddPresenterViewData extends ViewDataWithBackLink, CompanyNameAndNumber {
     authPersonEmail: string | undefined;
@@ -65,6 +66,7 @@ export class AddPresenterHandler extends GenericHandler {
     private initializeViewData (req: Request): void {
         const companyName = getExtraData(req.session, constants.COMPANY_NAME);
         const companyNumber = getExtraData(req.session, constants.COMPANY_NUMBER);
+        deleteSearchStringEmail(req.session as Session, companyNumber);
 
         this.viewData.lang = getTranslationsForView(req.lang, constants.ADD_PRESENTER_PAGE);
         this.viewData.backLinkHref = getManageAuthorisedPeopleFullUrl(companyNumber);

--- a/test/unit/src/routers/handlers/yourCompanies/addPresenterHandler.test.ts
+++ b/test/unit/src/routers/handlers/yourCompanies/addPresenterHandler.test.ts
@@ -114,6 +114,7 @@ describe("AddPresenterHandler", () => {
             const allGetExtraDataKeys = [
                 constants.COMPANY_NAME,
                 constants.COMPANY_NUMBER,
+                constants.SEARCH_STRING_EMAIL,
                 ...getExtraDataKeys
             ];
             const translations = { key: "value" };
@@ -123,6 +124,7 @@ describe("AddPresenterHandler", () => {
             getExtraDataSpy
                 .mockReturnValueOnce(companyName)
                 .mockReturnValueOnce(companyNumber)
+                .mockReturnValueOnce(undefined)
                 .mockReturnValueOnce(proposedEmail)
                 .mockReturnValueOnce(authorisedPersonEmail);
             const backLinkHref = "/manage-authorised-people/12345";


### PR DESCRIPTION
**Link to Jira**
https://companieshouse.atlassian.net/browse/SIV-758

**Description**
Bug: When you search for someone and then you complete the add new person journey, the manage authorised people page with your previous search results is shown instead of a fresh page. 
This PR fixes this issue.