### PR TITLE
SIV-769 770 assocation is unauthorised, display 'not authorised'

### DIFF
--- a/locales/cy/manage-authorised-people.json
+++ b/locales/cy/manage-authorised-people.json
@@ -17,6 +17,7 @@
     "name": "Enw",
     "no_results_found": "Ni chanfuwyd unrhyw ganlyniadau",
     "no_results_that_match": "Does dim cyfeiriadau e-bost sy’n cyd-fynd a’ch chwiliad. Ceisiwch chwilio eto gyda chyfeiriad e-bost gwahanol.",
+    "not_authorised": "Heb ei awdurdodi",
     "not_provided": "Heb ei ddarparu",
     "people_digitally_authorised_to_file_online": "Pobl sydd wedi’u hawdurdodi’n ddigidol i ffeilio ar-lein ar gyfer y cwmni hwn",
     "remove": "Dileu",

--- a/locales/cy/your-companies.json
+++ b/locales/cy/your-companies.json
@@ -18,6 +18,7 @@
     "for": "ar gyfer ",
     "no_results_found": "Ni chanfwyd unrhyw ganlyniadau",
     "no_results_that_match": "Nid oes unrhyw gwmnïau sy’n cyd-fynd a’ch chwiliad. Ceisiwch chwilio eto gyda rhif cwmni gwahanol.",
+    "not_authorised": "Heb ei awdurdodi",
     "remove": "Dileu",
     "restore_authorisation": "Adfer awdurdodiad",
     "result": "canlyniad",

--- a/locales/en/manage-authorised-people.json
+++ b/locales/en/manage-authorised-people.json
@@ -17,6 +17,7 @@
     "name": "Name",
     "no_results_found": "No results found",
     "no_results_that_match": "There are no email addresses that match your search. Try searching again with a different email address.",
+    "not_authorised": "Not authorised",
     "not_provided": "Not provided",
     "people_digitally_authorised_to_file_online": "People digitally authorised to file online for this company",
     "remove": "Remove",

--- a/locales/en/your-companies.json
+++ b/locales/en/your-companies.json
@@ -18,6 +18,7 @@
     "for": " for ",
     "no_results_found": "No results found",
     "no_results_that_match": "There are no companies that match your search. Try searching again with a different company number.",
+    "not_authorised": "Not authorised",
     "remove": "Remove",
     "restore_authorisation": "Restore authorisation",
     "result": "result",

--- a/src/views/manage-authorised-people.njk
+++ b/src/views/manage-authorised-people.njk
@@ -241,6 +241,17 @@
 
                     {% if (association.status === "migrated" or association.status === "unauthorised") %}
 
+                        {% if association.status === "unauthorised" %}
+                            {% set notAuthorisedText %}
+                                <div class="govuk-!-padding-bottom-2">
+                                    <strong class="govuk-tag govuk-tag--red">{{ lang.not_authorised }}</strong>
+                                </div>
+                            {% endset %}
+                        {% else %}
+                            {% set notAuthorisedText %}
+                            {% endset %}
+                        {% endif %}
+
                       
                         {% set visuallyHiddenRestoreText = lang.for %}
                         {% set restoreDigitalAuthUrl = restoreDigitalAuthBaseUrl + "/" + association.id %}
@@ -280,7 +291,7 @@
                                 text: lang.digital_authorisation
                             },
                             value: {
-                                text: ""
+                                html: notAuthorisedText
                             },
                             actions: {
                                 items: [

--- a/src/views/previously-added-companies.njk
+++ b/src/views/previously-added-companies.njk
@@ -179,6 +179,12 @@
                                 </dt>
                                 <dd class="govuk-summary-list__value">
                            
+                                    {% if (elem.status == "unauthorised") %}
+                                    <strong class="govuk-tag govuk-tag--red">
+                                        {{lang.not_authorised}}
+                                    </strong>
+                                     {% endif %}
+
                                 </dd>
                                 <dd class="govuk-summary-list__actions">
                                     {{restore_link}}

--- a/test/integration/your-companies/get.test.ts
+++ b/test/integration/your-companies/get.test.ts
@@ -10,7 +10,8 @@ import {
     oneConfirmedAssociation,
     twentyConfirmedAssociations,
     userAssociations,
-    userAssociationsWithNumberOfInvitations
+    userAssociationsWithNumberOfInvitations,
+    unauthorisedAssociation
 } from "../../mocks/associations.mock";
 import en from "../../../locales/en/your-companies.json";
 import cy from "../../../locales/cy/your-companies.json";
@@ -151,7 +152,20 @@ describe("GET /your-companies", () => {
         // Then
         expect(response.text).toContain(en.restore_authorisation);
         expect(response.text).not.toContain(en.authorised);
+        expect(response.text).not.toContain(en.not_authorised);
     });
+
+    it("should display 'not authorised' when association has status of unauthorised", async () => {
+        // Give
+        userAssociationsSpy.mockResolvedValue(unauthorisedAssociation);
+        getInvitationsSpy.mockResolvedValue(oneConfirmedAssociation);
+        // When
+        const response = await router.get("/your-companies?lang=en");
+        // Then
+        expect(response.text).toContain(en.restore_authorisation);
+        expect(response.text).toContain(en.not_authorised);
+    });
+
     it("should display 'Digitally authorised' when association has status of confirmed", async () => {
         // Give
         userAssociationsSpy.mockResolvedValue(oneConfirmedAssociation);

--- a/test/mocks/associations.mock.ts
+++ b/test/mocks/associations.mock.ts
@@ -1735,6 +1735,39 @@ export const migratedAssociation: AssociationList = {
     totalPages: 1
 } as AssociationList;
 
+export const unauthorisedAssociation: AssociationList = {
+    items: [
+        {
+            etag: "ABC",
+            id: "1234567890",
+            userId: "qwertyiop",
+            userEmail: "demo@ch.gov.uk",
+            displayName: "Not provided",
+            companyNumber: "NI038379",
+            companyName: "THE POLISH BREWERY",
+            companyStatus: CompanyStatuses.ACTIVE,
+            status: AssociationStatus.UNAUTHORISED,
+            createdAt: "2022-03-05T11:41:09.568+00:00 UTC",
+            approvedAt: "",
+            removedAt: "",
+            kind: "association",
+            approvalRoute: "invitation",
+            approvalExpiryAt: "2022-05-05T11:41:09.568+00:00 UTC",
+            links: {
+                self: "/12345"
+            }
+        }
+    ],
+    links: {
+        self: "http://localhost:8080/associations",
+        next: "http://localhost:8080/associations?page_index=2&itesm_per_page=15"
+    },
+    itemsPerPage: 15,
+    pageNumber: 0,
+    totalResults: 2,
+    totalPages: 1
+} as AssociationList;
+
 export const singleMigratedAssociation: Association = {
     etag: "ABC",
     id: "1234567890",


### PR DESCRIPTION
**Links to Jiras**
https://companieshouse.atlassian.net/browse/SIV-770
https://companieshouse.atlassian.net/browse/SIV-769
https://companieshouse.atlassian.net/browse/SIV-794

**Description**

- adds back the "not authorised" status for the  manage users page when association is 'unauthorised'
- adds back the "not authorised" status for the your-compaines page when association is 'unauthorised'

<img width="2812" height="5246" alt="chs local_your-companies_manage-authorised-people_NI038379" src="https://github.com/user-attachments/assets/0ac17c21-0281-4ac2-88e6-c322550e48f1" />

